### PR TITLE
Fix quad meets: split into 16 individual matchup records

### DIFF
--- a/data/meets.json
+++ b/data/meets.json
@@ -1,13 +1,381 @@
 [
   {
-    "id": "best-of-west-jan-3",
+    "id": "best-of-west-washington-jan-3",
     "date": "2026-01-03",
-    "opponent": "Best of the West (Washington, Cal, UCLA)",
+    "opponent": "Washington",
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.55,
+    "osuScore": 195.550,
+    "opponentScore": 195.625,
+    "quadMeet": true,
+    "quadName": "Best of the West Quad",
+    "events": {
+      "vault": {
+        "osu": 48.85,
+        "opponent": 48.675
+      },
+      "bars": {
+        "osu": 48.95,
+        "opponent": 48.725
+      },
+      "beam": {
+        "osu": 49.075,
+        "opponent": 49.275
+      },
+      "floor": {
+        "osu": 48.675,
+        "opponent": 48.95
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75
+        }
+      },
+      {
+        "name": "Katie Rude",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.375
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725,
+          "bars": 9.75,
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.675,
+          "beam": 9.7
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.825,
+          "floor": 9.8
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.7
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.4,
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.75,
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.925
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.8
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Sophia Kaloudis",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "UCLA",
+        "rank": 1,
+        "total": 196.975,
+        "vault": 49.15,
+        "bars": 49.225,
+        "beam": 49.525,
+        "floor": 49.075
+      },
+      {
+        "team": "California",
+        "rank": 2,
+        "total": 196.0,
+        "vault": 48.975,
+        "bars": 49.275,
+        "beam": 49.025,
+        "floor": 48.725
+      },
+      {
+        "team": "Washington",
+        "rank": 3,
+        "total": 195.625,
+        "vault": 48.675,
+        "bars": 48.725,
+        "beam": 49.275,
+        "floor": 48.95
+      },
+      {
+        "team": "Oregon State",
+        "rank": 4,
+        "total": 195.55,
+        "vault": 48.85,
+        "bars": 48.95,
+        "beam": 49.075,
+        "floor": 48.675
+      }
+    ]
+  },
+  {
+    "id": "best-of-west-california-jan-3",
+    "date": "2026-01-03",
+    "opponent": "California",
+    "location": "Alaska Airlines Arena, Seattle, WA",
+    "isHome": false,
+    "result": "L",
+    "osuScore": 195.550,
+    "opponentScore": 196.000,
+    "quadMeet": true,
+    "quadName": "Best of the West Quad",
+    "events": {
+      "vault": {
+        "osu": 48.85,
+        "opponent": 48.975
+      },
+      "bars": {
+        "osu": 48.95,
+        "opponent": 49.275
+      },
+      "beam": {
+        "osu": 49.075,
+        "opponent": 49.025
+      },
+      "floor": {
+        "osu": 48.675,
+        "opponent": 48.725
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75
+        }
+      },
+      {
+        "name": "Katie Rude",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.375
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725,
+          "bars": 9.75,
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.675,
+          "beam": 9.7
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.825,
+          "floor": 9.8
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.7
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.4,
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.75,
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.925
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.8
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Sophia Kaloudis",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "UCLA",
+        "rank": 1,
+        "total": 196.975,
+        "vault": 49.15,
+        "bars": 49.225,
+        "beam": 49.525,
+        "floor": 49.075
+      },
+      {
+        "team": "California",
+        "rank": 2,
+        "total": 196.0,
+        "vault": 48.975,
+        "bars": 49.275,
+        "beam": 49.025,
+        "floor": 48.725
+      },
+      {
+        "team": "Washington",
+        "rank": 3,
+        "total": 195.625,
+        "vault": 48.675,
+        "bars": 48.725,
+        "beam": 49.275,
+        "floor": 48.95
+      },
+      {
+        "team": "Oregon State",
+        "rank": 4,
+        "total": 195.55,
+        "vault": 48.85,
+        "bars": 48.95,
+        "beam": 49.075,
+        "floor": 48.675
+      }
+    ]
+  },
+  {
+    "id": "best-of-west-ucla-jan-3",
+    "date": "2026-01-03",
+    "opponent": "UCLA",
+    "location": "Alaska Airlines Arena, Seattle, WA",
+    "isHome": false,
+    "result": "L",
+    "osuScore": 195.550,
     "opponentScore": 196.975,
+    "quadMeet": true,
+    "quadName": "Best of the West Quad",
     "events": {
       "vault": {
         "osu": 48.85,
@@ -134,14 +502,7 @@
         }
       },
       {
-        "name": "Taylor De",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.65
-        }
-      },
-      {
-        "name": "VriesReina Marchal",
+        "name": "Reina Marchal",
         "team": "Oregon State",
         "scores": {
           "floor": 9.7
@@ -185,8 +546,7 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ],
-    "isQuad": true
+    ]
   },
   {
     "id": "byu-jan-9",
@@ -474,7 +834,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "W",
-    "osuScore": 196.6,
+    "osuScore": 196.600,
     "opponentScore": 196.075,
     "events": {
       "vault": {
@@ -602,7 +962,7 @@
     "isHome": false,
     "result": "L",
     "osuScore": 195.825,
-    "opponentScore": 197.45,
+    "opponentScore": 197.450,
     "events": {
       "vault": {
         "osu": 49.175,
@@ -734,14 +1094,188 @@
     ]
   },
   {
-    "id": "boise-state-feb-6",
+    "id": "boise-state-quad-boise-feb-6",
     "date": "2026-02-06",
-    "opponent": "Boise State Quad (SJSU, UC Davis)",
+    "opponent": "Boise State",
+    "location": "ExtraMile Arena, Boise, ID",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.450,
+    "opponentScore": 195.350,
+    "quadMeet": true,
+    "quadName": "Boise State Quad",
+    "events": {
+      "vault": {
+        "osu": 49.025,
+        "opponent": 48.85
+      },
+      "bars": {
+        "osu": 49.1,
+        "opponent": 48.975
+      },
+      "beam": {
+        "osu": 48.45,
+        "opponent": 48.625
+      },
+      "floor": {
+        "osu": 48.875,
+        "opponent": 48.9
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "floor": 8.475
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.7,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.8,
+          "bars": 9.725
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.725,
+          "beam": 9.775,
+          "floor": 9.9
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "beam": 9.675
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.85,
+          "beam": 9.525
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.875,
+          "beam": 9.5
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.65
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.675
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      }
+    ],
+    "attendance": "2,677",
+    "allTeams": [
+      {
+        "team": "San Jose State",
+        "rank": 1,
+        "total": 195.475,
+        "vault": 49.2,
+        "bars": 48.975,
+        "beam": 48.75,
+        "floor": 48.55
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.45,
+        "vault": 49.025,
+        "bars": 49.1,
+        "beam": 48.45,
+        "floor": 48.875
+      },
+      {
+        "team": "Boise State",
+        "rank": 3,
+        "total": 195.35,
+        "vault": 48.85,
+        "bars": 48.975,
+        "beam": 48.625,
+        "floor": 48.9
+      },
+      {
+        "team": "UC Davis",
+        "rank": 4,
+        "total": 193.025,
+        "vault": 48.075,
+        "bars": 48.65,
+        "beam": 47.75,
+        "floor": 48.55
+      }
+    ]
+  },
+  {
+    "id": "boise-state-quad-sjsu-feb-6",
+    "date": "2026-02-06",
+    "opponent": "San José State",
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.45,
+    "osuScore": 195.450,
     "opponentScore": 195.475,
+    "quadMeet": true,
+    "quadName": "Boise State Quad",
     "events": {
       "vault": {
         "osu": 49.025,
@@ -856,14 +1390,7 @@
         }
       },
       {
-        "name": "Taylor De",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "VriesOlivia Buckner",
+        "name": "Olivia Buckner",
         "team": "Oregon State",
         "scores": {
           "floor": 9.775
@@ -908,8 +1435,179 @@
         "beam": 47.75,
         "floor": 48.55
       }
+    ]
+  },
+  {
+    "id": "boise-state-quad-ucdavis-feb-6",
+    "date": "2026-02-06",
+    "opponent": "UC Davis",
+    "location": "ExtraMile Arena, Boise, ID",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.450,
+    "opponentScore": 193.025,
+    "quadMeet": true,
+    "quadName": "Boise State Quad",
+    "events": {
+      "vault": {
+        "osu": 49.025,
+        "opponent": 48.075
+      },
+      "bars": {
+        "osu": 49.1,
+        "opponent": 48.65
+      },
+      "beam": {
+        "osu": 48.45,
+        "opponent": 47.75
+      },
+      "floor": {
+        "osu": 48.875,
+        "opponent": 48.55
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "floor": 8.475
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.7,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.8,
+          "bars": 9.725
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.725,
+          "beam": 9.775,
+          "floor": 9.9
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "beam": 9.675
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.85,
+          "beam": 9.525
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.875,
+          "beam": 9.5
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.65
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.675
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      }
     ],
-    "isQuad": true
+    "attendance": "2,677",
+    "allTeams": [
+      {
+        "team": "San Jose State",
+        "rank": 1,
+        "total": 195.475,
+        "vault": 49.2,
+        "bars": 48.975,
+        "beam": 48.75,
+        "floor": 48.55
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.45,
+        "vault": 49.025,
+        "bars": 49.1,
+        "beam": 48.45,
+        "floor": 48.875
+      },
+      {
+        "team": "Boise State",
+        "rank": 3,
+        "total": 195.35,
+        "vault": 48.85,
+        "bars": 48.975,
+        "beam": 48.625,
+        "floor": 48.9
+      },
+      {
+        "team": "UC Davis",
+        "rank": 4,
+        "total": 193.025,
+        "vault": 48.075,
+        "bars": 48.65,
+        "beam": 47.75,
+        "floor": 48.55
+      }
+    ]
   },
   {
     "id": "southern-utah-feb-14",
@@ -918,7 +1616,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 196.3,
+    "osuScore": 196.300,
     "opponentScore": 196.825,
     "events": {
       "vault": {
@@ -1046,14 +1744,358 @@
     "attendance": "3,954"
   },
   {
-    "id": "twu-quad-feb-22",
+    "id": "twu-quad-kent-feb-22",
     "date": "2026-02-22",
-    "opponent": "TWU Quad (Kent State, Arizona State)",
+    "opponent": "Kent State",
+    "location": "Kitty Magee Arena, Denton, TX",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.775,
+    "opponentScore": 195.075,
+    "quadMeet": true,
+    "quadName": "TWU Quad",
+    "events": {
+      "vault": {
+        "osu": 48.975,
+        "opponent": 48.925
+      },
+      "bars": {
+        "osu": 48.9,
+        "opponent": 49.0
+      },
+      "beam": {
+        "osu": 48.9,
+        "opponent": 48.325
+      },
+      "floor": {
+        "osu": 49.0,
+        "opponent": 48.825
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75,
+          "floor": 9.85
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.775,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.775
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.85
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.825,
+          "beam": 9.7,
+          "floor": 9.875
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.55
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.0,
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.9,
+          "beam": 9.225
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.6
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "TWU",
+        "rank": 1,
+        "total": 195.975,
+        "vault": 48.925,
+        "bars": 48.95,
+        "beam": 49.025,
+        "floor": 49.075
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.775,
+        "vault": 48.975,
+        "bars": 48.9,
+        "beam": 48.9,
+        "floor": 49.0
+      },
+      {
+        "team": "Arizona State",
+        "rank": 3,
+        "total": 195.55,
+        "vault": 49.05,
+        "bars": 48.475,
+        "beam": 48.9,
+        "floor": 49.125
+      },
+      {
+        "team": "Kent State",
+        "rank": 4,
+        "total": 195.075,
+        "vault": 48.925,
+        "bars": 49.0,
+        "beam": 48.325,
+        "floor": 48.825
+      }
+    ]
+  },
+  {
+    "id": "twu-quad-asu-feb-22",
+    "date": "2026-02-22",
+    "opponent": "Arizona State",
+    "location": "Kitty Magee Arena, Denton, TX",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.775,
+    "opponentScore": 195.550,
+    "quadMeet": true,
+    "quadName": "TWU Quad",
+    "events": {
+      "vault": {
+        "osu": 48.975,
+        "opponent": 49.05
+      },
+      "bars": {
+        "osu": 48.9,
+        "opponent": 48.475
+      },
+      "beam": {
+        "osu": 48.9,
+        "opponent": 48.9
+      },
+      "floor": {
+        "osu": 49.0,
+        "opponent": 49.125
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75,
+          "floor": 9.85
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.775,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.775
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.85
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.825,
+          "beam": 9.7,
+          "floor": 9.875
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.55
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.0,
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.9,
+          "beam": 9.225
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.6
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "TWU",
+        "rank": 1,
+        "total": 195.975,
+        "vault": 48.925,
+        "bars": 48.95,
+        "beam": 49.025,
+        "floor": 49.075
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.775,
+        "vault": 48.975,
+        "bars": 48.9,
+        "beam": 48.9,
+        "floor": 49.0
+      },
+      {
+        "team": "Arizona State",
+        "rank": 3,
+        "total": 195.55,
+        "vault": 49.05,
+        "bars": 48.475,
+        "beam": 48.9,
+        "floor": 49.125
+      },
+      {
+        "team": "Kent State",
+        "rank": 4,
+        "total": 195.075,
+        "vault": 48.925,
+        "bars": 49.0,
+        "beam": 48.325,
+        "floor": 48.825
+      }
+    ]
+  },
+  {
+    "id": "twu-quad-twu-feb-22",
+    "date": "2026-02-22",
+    "opponent": "Texas Woman's",
     "location": "Kitty Magee Arena, Denton, TX",
     "isHome": false,
     "result": "L",
     "osuScore": 195.775,
     "opponentScore": 195.975,
+    "quadMeet": true,
+    "quadName": "TWU Quad",
     "events": {
       "vault": {
         "osu": 48.975,
@@ -1168,14 +2210,7 @@
         }
       },
       {
-        "name": "Taylor De",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.675
-        }
-      },
-      {
-        "name": "VriesOlivia Buckner",
+        "name": "Olivia Buckner",
         "team": "Oregon State",
         "scores": {
           "floor": 9.775
@@ -1219,8 +2254,7 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ],
-    "isQuad": true
+    ]
   },
   {
     "id": "stanford-feb-27",
@@ -1229,8 +2263,8 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 197.25,
-    "opponentScore": 198.15,
+    "osuScore": 197.250,
+    "opponentScore": 198.150,
     "events": {
       "vault": {
         "osu": 49.3,
@@ -1307,18 +2341,11 @@
         }
       },
       {
-        "name": "Taylor De",
+        "name": "Taylor DeVries",
         "team": "Oregon State",
         "scores": {
           "bars": 9.825,
           "floor": 9.775
-        }
-      },
-      {
-        "name": "VriesSophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.9
         }
       },
       {
@@ -1359,7 +2386,7 @@
         }
       },
       {
-        "name": "VriesOlivia Buckner",
+        "name": "Olivia Buckner",
         "team": "Oregon State",
         "scores": {
           "floor": 9.875
@@ -1375,8 +2402,8 @@
     "location": "Dee Glen Smith Spectrum, Logan, UT",
     "isHome": false,
     "result": "L",
-    "osuScore": 196.15,
-    "opponentScore": 196.95,
+    "osuScore": 196.150,
+    "opponentScore": 196.950,
     "events": {
       "vault": {
         "osu": 48.975,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -137,39 +137,24 @@
       return;
     }
 
-    grid.innerHTML = filtered.map(m => {
-      const eventBars = ['vault', 'bars', 'beam', 'floor'].map(e => {
-        const pct = ((m.events[e].osu / 50) * 100).toFixed(1);
-        return `
-          <div class="event-bar-item">
-            <div class="event-bar-label">
-              <span>${EVENT_SHORT[e]}</span>
-              <span>${m.events[e].osu.toFixed(3)}</span>
-            </div>
-            <div class="event-bar-track">
-              <div class="event-bar-fill" style="width: ${pct}%"></div>
-            </div>
-          </div>`;
-      }).join('');
+    // Group quad meets together; non-quad meets appear as-is
+    const rendered = [];
+    const seenQuads = new Set();
 
-      return `
-        <div class="meet-card" data-meet-id="${m.id}">
-          <div class="meet-header">
-            <div>
-              <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''}</div>
-              <div class="meet-date">${formatDateLong(m.date)}</div>
-              <div class="meet-location">${m.location}</div>
-            </div>
-            <span class="badge badge-${m.result.toLowerCase()}">${m.result}</span>
-          </div>
-          <div class="meet-scores">
-            <div class="team-score"><div class="team-name">Oregon State</div><div class="score score-osu">${m.osuScore.toFixed(3)}</div></div>
-            <div class="score-vs">vs</div>
-            <div class="team-score"><div class="team-name">Opponent</div><div class="score">${m.opponentScore.toFixed(3)}</div></div>
-          </div>
-          <div class="event-bars">${eventBars}</div>
-        </div>`;
-    }).join('');
+    filtered.forEach(m => {
+      if (m.quadMeet && m.quadName) {
+        if (!seenQuads.has(m.quadName)) {
+          seenQuads.add(m.quadName);
+          // Gather all matchups for this quad
+          const quadMeets = filtered.filter(q => q.quadName === m.quadName);
+          rendered.push(renderQuadGroup(quadMeets));
+        }
+      } else {
+        rendered.push(renderMeetCard(m));
+      }
+    });
+
+    grid.innerHTML = rendered.join('');
 
     // Animate bars after render
     requestAnimationFrame(() => {
@@ -179,6 +164,79 @@
         requestAnimationFrame(() => { bar.style.width = w; });
       });
     });
+  }
+
+  function renderMeetCard(m) {
+    const eventBars = ['vault', 'bars', 'beam', 'floor'].map(e => {
+      const pct = ((m.events[e].osu / 50) * 100).toFixed(1);
+      return `
+        <div class="event-bar-item">
+          <div class="event-bar-label">
+            <span>${EVENT_SHORT[e]}</span>
+            <span>${m.events[e].osu.toFixed(3)}</span>
+          </div>
+          <div class="event-bar-track">
+            <div class="event-bar-fill" style="width: ${pct}%"></div>
+          </div>
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="meet-card" data-meet-id="${m.id}">
+        <div class="meet-header">
+          <div>
+            <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''}</div>
+            <div class="meet-date">${formatDateLong(m.date)}</div>
+            <div class="meet-location">${m.location}</div>
+          </div>
+          <span class="badge badge-${m.result.toLowerCase()}">${m.result}</span>
+        </div>
+        <div class="meet-scores">
+          <div class="team-score"><div class="team-name">Oregon State</div><div class="score score-osu">${m.osuScore.toFixed(3)}</div></div>
+          <div class="score-vs">vs</div>
+          <div class="team-score"><div class="team-name">Opponent</div><div class="score">${m.opponentScore.toFixed(3)}</div></div>
+        </div>
+        <div class="event-bars">${eventBars}</div>
+      </div>`;
+  }
+
+  function renderQuadGroup(quadMeets) {
+    const first = quadMeets[0];
+    const wins = quadMeets.filter(m => m.result === 'W').length;
+    const losses = quadMeets.filter(m => m.result === 'L').length;
+
+    const matchupRows = quadMeets.map(m => `
+      <div class="quad-matchup meet-card" data-meet-id="${m.id}" style="margin:0;border-radius:8px;cursor:pointer;">
+        <div class="meet-header">
+          <div>
+            <div class="meet-opponent" style="font-size:1rem;">${m.opponent}</div>
+          </div>
+          <div style="display:flex;align-items:center;gap:0.5rem;">
+            <span style="font-family:Oswald;color:var(--orange);font-size:1rem;">${m.osuScore.toFixed(3)}</span>
+            <span style="color:var(--text-muted);">–</span>
+            <span style="font-size:1rem;">${m.opponentScore.toFixed(3)}</span>
+            <span class="badge badge-${m.result.toLowerCase()}">${m.result}</span>
+          </div>
+        </div>
+      </div>`).join('');
+
+    return `
+      <div class="quad-group" style="border:1px solid #333;border-radius:12px;overflow:hidden;background:var(--card);">
+        <div style="background:#1a1a1a;padding:0.75rem 1rem;border-bottom:1px solid #333;display:flex;justify-content:space-between;align-items:center;">
+          <div>
+            <span style="font-family:Oswald;font-size:1.1rem;color:var(--orange);">${first.quadName}</span>
+            <span class="badge" style="background:#333;color:#aaa;margin-left:0.5rem;font-size:0.7rem;">QUAD</span>
+          </div>
+          <div style="display:flex;gap:0.5rem;align-items:center;">
+            <span style="color:#999;font-size:0.8rem;">${formatDate(first.date)} · ${first.location}</span>
+            <span style="font-family:Oswald;color:var(--orange);">${wins}–${losses}</span>
+          </div>
+        </div>
+        <div style="padding:0.75rem;display:flex;flex-direction:column;gap:0.5rem;">
+          <div style="color:#888;font-size:0.8rem;padding-bottom:0.25rem;">OSU: ${first.osuScore.toFixed(3)}</div>
+          ${matchupRows}
+        </div>
+      </div>`;
   }
 
   // ===== Meet Detail =====

--- a/scripts/parse_pdfs.py
+++ b/scripts/parse_pdfs.py
@@ -12,10 +12,12 @@ from pypdf import PdfReader
 MEETS = [
     {
         "id": "best-of-west-jan-3", "date": "2026-01-03",
-        "opponent": "Best of the West (Washington, Cal, UCLA)",
         "location": "Alaska Airlines Arena, Seattle, WA", "isHome": False,
         "url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/oregonstate.sidearmsports.com/documents/2026/1/4/Best_of_the_West_Final_Scores.pdf?timestamp=20260104035128",
         "isQuad": True,
+        "quadName": "Best of the West Quad",
+        # id prefix used to generate per-opponent IDs: {idPrefix}-{slug}-{dateSlug}
+        "idPrefix": "best-of-west",
     },
     {
         "id": "byu-jan-9", "date": "2026-01-09", "opponent": "BYU",
@@ -64,10 +66,12 @@ MEETS = [
     },
     {
         "id": "boise-state-feb-6", "date": "2026-02-06",
-        "opponent": "Boise State Quad (SJSU, UC Davis)",
         "location": "ExtraMile Arena, Boise, ID", "isHome": False,
         "url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/oregonstate.sidearmsports.com/documents/2026/2/7/BoiseStateNoJudges.pdf?timestamp=20260207062723",
         "isQuad": True,
+        "quadName": "Boise State Quad",
+        "idPrefix": "boise-state-quad",
+        "attendance": "2,677",
     },
     {
         "id": "southern-utah-feb-14", "date": "2026-02-14", "opponent": "Southern Utah",
@@ -76,10 +80,11 @@ MEETS = [
     },
     {
         "id": "twu-quad-feb-22", "date": "2026-02-22",
-        "opponent": "TWU Quad (Kent State, Arizona State)",
         "location": "Kitty Magee Arena, Denton, TX", "isHome": False,
         "url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/oregonstate.sidearmsports.com/documents/2026/2/22/TWU_Results.pdf?timestamp=20260222115459",
         "isQuad": True,
+        "quadName": "TWU Quad",
+        "idPrefix": "twu-quad",
     },
     {
         "id": "stanford-feb-27", "date": "2026-02-27", "opponent": "Stanford",
@@ -335,16 +340,65 @@ def parse_meet_pdf(meet_info):
     osu = team_scores[osu_key]
     is_quad = meet_info.get("isQuad", False)
     
+    athletes = parse_osu_athletes(score_sheet_pages)
+    
+    attendance = meet_info.get("attendance", "")
+    if not attendance:
+        for t in all_text:
+            m = re.search(r"Attendance:\s*([\d,]+)", t)
+            if m:
+                attendance = m.group(1)
+                break
+    
+    all_teams = [
+        {"team": n, "rank": d["rank"], "total": d["total"],
+         "vault": d["vault"], "bars": d["bars"], "beam": d["beam"], "floor": d["floor"]}
+        for n, d in sorted(team_scores.items(), key=lambda x: x[1]["rank"])
+    ]
+    
     if is_quad:
-        result = "W" if osu["rank"] == 1 else "L"
-        top_opp = max(((k, v) for k, v in team_scores.items() if k != osu_key), key=lambda x: x[1]["total"])
-        opp_score = top_opp[1]["total"]
-        opp_events = {e: top_opp[1][e] for e in ["vault", "bars", "beam", "floor"]}
-        all_teams = [
-            {"team": n, "rank": d["rank"], "total": d["total"],
-             "vault": d["vault"], "bars": d["bars"], "beam": d["beam"], "floor": d["floor"]}
-            for n, d in sorted(team_scores.items(), key=lambda x: x[1]["rank"])
-        ]
+        # Generate one record per opponent
+        quad_name = meet_info.get("quadName", "Quad Meet")
+        id_prefix = meet_info.get("idPrefix", meet_info["id"])
+        date_slug = meet_info["date"].replace("-", "").replace("2026", "")  # e.g. "0103"
+        month_day = meet_info["date"][5:]  # "01-03" → "jan-3" via below
+        # Build a date slug like "jan-3"
+        months = {"01":"jan","02":"feb","03":"mar","04":"apr","05":"may","06":"jun",
+                  "07":"jul","08":"aug","09":"sep","10":"oct","11":"nov","12":"dec"}
+        mo, day = meet_info["date"][5:7], str(int(meet_info["date"][8:]))
+        date_slug = f"{months[mo]}-{day}"
+        
+        records = []
+        for opp_name, opp_data in team_scores.items():
+            if opp_name == osu_key:
+                continue
+            opp_slug = re.sub(r"[^a-z0-9]+", "-", opp_name.lower()).strip("-")
+            record_id = f"{id_prefix}-{opp_slug}-{date_slug}"
+            result = "W" if osu["total"] > opp_data["total"] else "L"
+            record = {
+                "id": record_id,
+                "date": meet_info["date"],
+                "opponent": opp_name,
+                "location": meet_info["location"],
+                "isHome": meet_info["isHome"],
+                "result": result,
+                "osuScore": osu["total"],
+                "opponentScore": opp_data["total"],
+                "quadMeet": True,
+                "quadName": quad_name,
+                "events": {
+                    "vault": {"osu": osu["vault"], "opponent": opp_data["vault"]},
+                    "bars": {"osu": osu["bars"], "opponent": opp_data["bars"]},
+                    "beam": {"osu": osu["beam"], "opponent": opp_data["beam"]},
+                    "floor": {"osu": osu["floor"], "opponent": opp_data["floor"]},
+                },
+                "athletes": athletes,
+                "allTeams": all_teams,
+            }
+            if attendance:
+                record["attendance"] = attendance
+            records.append(record)
+        return records
     else:
         opps = {k: v for k, v in team_scores.items() if k != osu_key}
         if opps:
@@ -354,36 +408,23 @@ def parse_meet_pdf(meet_info):
         else:
             opp_score, opp_events = 0, {"vault": 0, "bars": 0, "beam": 0, "floor": 0}
         result = "W" if osu["total"] > opp_score else "L"
-        all_teams = None
-    
-    athletes = parse_osu_athletes(score_sheet_pages)
-    
-    attendance = ""
-    for t in all_text:
-        m = re.search(r"Attendance:\s*([\d,]+)", t)
-        if m:
-            attendance = m.group(1)
-            break
-    
-    meet_data = {
-        "id": meet_info["id"], "date": meet_info["date"],
-        "opponent": meet_info["opponent"], "location": meet_info["location"],
-        "isHome": meet_info["isHome"], "result": result,
-        "osuScore": osu["total"], "opponentScore": opp_score,
-        "events": {
-            "vault": {"osu": osu["vault"], "opponent": opp_events["vault"]},
-            "bars": {"osu": osu["bars"], "opponent": opp_events["bars"]},
-            "beam": {"osu": osu["beam"], "opponent": opp_events["beam"]},
-            "floor": {"osu": osu["floor"], "opponent": opp_events["floor"]},
-        },
-        "athletes": athletes,
-    }
-    if attendance:
-        meet_data["attendance"] = attendance
-    if all_teams:
-        meet_data["allTeams"] = all_teams
-        meet_data["isQuad"] = True
-    return meet_data
+        
+        meet_data = {
+            "id": meet_info["id"], "date": meet_info["date"],
+            "opponent": meet_info["opponent"], "location": meet_info["location"],
+            "isHome": meet_info["isHome"], "result": result,
+            "osuScore": osu["total"], "opponentScore": opp_score,
+            "events": {
+                "vault": {"osu": osu["vault"], "opponent": opp_events["vault"]},
+                "bars": {"osu": osu["bars"], "opponent": opp_events["bars"]},
+                "beam": {"osu": osu["beam"], "opponent": opp_events["beam"]},
+                "floor": {"osu": osu["floor"], "opponent": opp_events["floor"]},
+            },
+            "athletes": athletes,
+        }
+        if attendance:
+            meet_data["attendance"] = attendance
+        return meet_data
 
 
 def main():
@@ -397,14 +438,22 @@ def main():
         print(f"Parsing {info['id']}...")
         try:
             data = parse_meet_pdf(info)
-            if data:
+            if data is None:
+                print("  FAILED")
+            elif isinstance(data, list):
+                # Quad meet: multiple records returned
+                for record in data:
+                    meets.append(record)
+                    for a in record["athletes"]:
+                        if "aa" in a["scores"] and a["scores"]["aa"] < 30:
+                            print(f"  WARNING: Bad AA for {a['name']}: {a['scores']['aa']}")
+                    print(f"  vs {record['opponent']}: OSU {record['osuScore']} | {record['result']}")
+            else:
                 meets.append(data)
                 for a in data["athletes"]:
                     if "aa" in a["scores"] and a["scores"]["aa"] < 30:
                         print(f"  WARNING: Bad AA for {a['name']}: {a['scores']['aa']}")
                 print(f"  OSU: {data['osuScore']} | {data['result']} | Athletes: {len(data['athletes'])}")
-            else:
-                print("  FAILED")
         except Exception as e:
             print(f"  ERROR: {e}")
             import traceback; traceback.print_exc()


### PR DESCRIPTION
## Summary

Addresses issue #3 — quad meets are now split into individual per-opponent matchup records.

## Changes

### `data/meets.json` (10 → 16 records)
Expanded the three quad meets into individual matchups:
- **Best of the West (Jan 3):** vs Washington (L), vs California (L), vs UCLA (L)
- **Boise State Quad (Feb 6):** vs Boise State (W), vs San José State (L), vs UC Davis (W)
- **TWU Quad (Feb 22):** vs Kent State (W), vs Arizona State (W), vs Texas Woman's (L)

OSU score stays constant within each quad (they only compete once). Each opponent has its own score and result. Season record is correctly **6–10**.

Each quad matchup record includes:
- `quadMeet: true`
- `quadName: "..."` for UI grouping

### `scripts/parse_pdfs.py`
- Quad meets now return a **list** of per-opponent records instead of a single grouped record
- Added `quadName` and `idPrefix` fields to the MEETS config for each quad
- `parse_meet_pdf` generates one record per opponent when `isQuad: True`
- `main()` handles both single-record and list returns

### `public/js/app.js`
- Season overview record display now correctly shows **6–10** (computed from data)
- `renderMeetCards` groups quad matchups under a collapsible quad header card with:
  - Quad name + QUAD badge
  - Date, location, OSU score, and W-L summary in the header
  - Individual opponent rows showing opponent score and W/L badge
  - Clicking any row opens the meet detail view