### PR TITLE
feat: show home/away indicator on all meet references throughout UI

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -358,6 +358,42 @@ main {
   margin-left: 0.5rem;
 }
 
+/* Home / Away pills */
+.ha-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  border-radius: 4px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.ha-pill-home {
+  background: #D73F09;
+  color: #fff;
+}
+
+.ha-pill-away {
+  background: #3a3a3a;
+  color: #aaa;
+}
+
+/* Full label (cards, detail headers) */
+.ha-pill-full {
+  font-size: 0.72rem;
+  padding: 0.18rem 0.55rem;
+  margin-left: 0.5rem;
+}
+
+/* Short label (tables, leaderboards — "H" / "A") */
+.ha-pill-short {
+  font-size: 0.65rem;
+  padding: 0.12rem 0.35rem;
+  margin-left: 0.35rem;
+}
+
 .meet-scores {
   display: flex;
   justify-content: space-between;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,6 +26,19 @@
     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'long', day: 'numeric', year: 'numeric' });
   }
 
+  /**
+   * Returns a home/away pill HTML string.
+   * @param {boolean} isHome
+   * @param {'short'|'full'} size  - 'short' → "H"/"A", 'full' → "🏠 Home"/"✈️ Away"
+   */
+  function haPill(isHome, size = 'full') {
+    const cls = `ha-pill ha-pill-${isHome ? 'home' : 'away'} ha-pill-${size}`;
+    if (size === 'short') {
+      return `<span class="${cls}">${isHome ? 'H' : 'A'}</span>`;
+    }
+    return `<span class="${cls}">${isHome ? '🏠 Home' : '✈️ Away'}</span>`;
+  }
+
   // ===== Data Loading =====
   async function loadData() {
     try {
@@ -156,7 +169,7 @@
         <div class="meet-card" data-meet-id="${m.id}">
           <div class="meet-header">
             <div>
-              <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''}</div>
+              <div class="meet-opponent">${m.opponent}${haPill(m.isHome, 'full')}</div>
               <div class="meet-date">${formatDateLong(m.date)}</div>
               <div class="meet-location">${m.location}</div>
             </div>
@@ -253,7 +266,7 @@
           <div>
             <div class="meet-opponent" style="font-size:1.5rem;">vs ${meet.opponent}</div>
             <div class="meet-date">${formatDateLong(meet.date)}</div>
-            <div class="meet-location">${meet.location}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
+            <div class="meet-location" style="display:flex;align-items:center;gap:0.4rem;flex-wrap:wrap;">${haPill(meet.isHome, 'full')} · ${meet.location}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
           </div>
           <span class="badge badge-${meet.result.toLowerCase()}" style="font-size:1rem;padding:0.3rem 0.8rem;">${meet.result}</span>
         </div>
@@ -379,13 +392,16 @@
 
     // Meet history table
     const historyRows = p.meets.map(m => {
+      const meetData = meets.find(meet => meet.id === m.meetId);
+      const isHome = meetData ? meetData.isHome : null;
       const cells = ['vault', 'bars', 'beam', 'floor'].map(e => {
         if (m.scores[e] === undefined) return '<td style="color:var(--text-muted)">—</td>';
         const isBest = p.bests[e] === m.scores[e];
         return `<td class="${isBest ? 'personal-best' : ''}">${m.scores[e].toFixed(3)}${isBest ? ' ★' : ''}</td>`;
       }).join('');
       const aa = m.scores.aa ? `<td>${m.scores.aa.toFixed(3)}</td>` : '<td style="color:var(--text-muted)">—</td>';
-      return `<tr><td>${formatDate(m.date)}</td><td>${m.opponent}</td>${cells}${aa}</tr>`;
+      const haTag = isHome !== null ? haPill(isHome, 'short') : '';
+      return `<tr><td>${formatDate(m.date)}</td><td>${m.opponent}${haTag}</td>${cells}${aa}</tr>`;
     }).join('');
 
     detail.innerHTML = `
@@ -453,6 +469,7 @@
             meetDate: meet.date,
             opponent: meet.opponent,
             meetId: meet.id,
+            isHome: meet.isHome,
           });
         }
       });
@@ -472,7 +489,7 @@
         <div class="lb-rank ${i < 3 ? 'top-3' : ''}">${i + 1}</div>
         <div class="lb-info">
           <div class="lb-name">${s.name}</div>
-          <div class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}</div>
+          <div class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}${haPill(s.isHome, 'short')}</div>
         </div>
         <div class="lb-score">${s.score.toFixed(3)}</div>
       </div>`).join('');


### PR DESCRIPTION
## Summary

Adds visual Home/Away indicators across all meet references in the UI, using the existing `isHome` boolean on meet objects.

## Changes

### New utility function
- `haPill(isHome, size)` — returns a styled pill span. `size='full'` gives '🏠 Home'/'✈️ Away', `size='short'` gives 'H'/'A'.

### Season Overview (meet cards)
- Full pill (`🏠 Home` / `✈️ Away`) displayed next to opponent name

### Meet Detail page header
- Full pill prefixed to the location line: `🏠 Home · Gill Coliseum, Corvallis, OR`

### Gymnast Profile — score history table
- Short `H`/`A` pill in the Opponent column (compact, non-cluttering)

### Event Leaderboard rows
- Short `H`/`A` pill appended to the meet context line

### CSS
- New classes: `.ha-pill`, `.ha-pill-home` (orange #D73F09), `.ha-pill-away` (grey #3a3a3a/#aaa), `.ha-pill-full`, `.ha-pill-short`

No data changes — `isHome` already present in `data/meets.json`.

Addresses issue #7