### PR TITLE
feat: add cross-linking, hash routing, breadcrumbs, and meet recaps (#6)

### DIFF
--- a/data/meets.json
+++ b/data/meets.json
@@ -6,7 +6,7 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
+    "osuScore": 195.55,
     "opponentScore": 195.625,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
@@ -180,7 +180,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\nCamryn Richardson , competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT.\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad"
   },
   {
     "id": "best-of-west-california-jan-3",
@@ -189,8 +191,8 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
-    "opponentScore": 196.000,
+    "osuScore": 195.55,
+    "opponentScore": 196.0,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
     "events": {
@@ -363,7 +365,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\nCamryn Richardson , competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT.\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad"
   },
   {
     "id": "best-of-west-ucla-jan-3",
@@ -372,7 +376,7 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
+    "osuScore": 195.55,
     "opponentScore": 196.975,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
@@ -546,7 +550,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\nCamryn Richardson , competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT.\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad"
   },
   {
     "id": "byu-jan-9",
@@ -691,7 +697,9 @@
         }
       }
     ],
-    "attendance": "4,002"
+    "attendance": "4,002",
+    "recap": "PROVO, Utah \u2013 Oregon State gymnastics tallied the highest rotation score of either team in its dual against BYU, a 49.200 on floor exercise, but that wasn't enough as the Beavers finished with a 194.525 and fell to the Cougars on Friday inside the Marriott Center.\n\nEllie Weaver had a great meet for the Beavers in Provo, earning a 9.800 on bars in the team's first rotation before posting a 9.850 in the anchor spot on beam, which OSU competed in the fourth and final rotation. For the Vancouver, Wash., native, her performance was a near tenth of a point average improvement from last week, having posted a pair of 9.750s in Seattle.\n\nSophia Esposito won her first event title of the season on Friday, earning a 9.900 on floor to tie for the meet's highest score, also adding a 9.800 for her vault. Esposito, who earned a trio of 9.800-plus scores last weekend, also competed on beam along with Lauren Letzsch , who earned her second 9.800-plus score in as many weeks.\n\nUtah natives Olivia Buckner and Kaylee Cheek both competed close to home, with Buckner earning a 9.800 for her vault and Cheek hitting on both routines; Camryn Richardson added a 9.800 for her bars routine and was also given a 9.750 in her first floor exercise appearance of the season.\n\nThe Beaver floor lineup earned the highest rotation score of either team in Friday's competition, combining for a 49.200. Paulina Vargas scored a 9.825 that was followed by Richardson's 9.750, setting the stage for the back half of the lineup, which featured a Savannah Miller 9.875, Reina Marchal 9.850 and Esposito's 9.900.\n\nOregon State gymnastics returns home for its next two meets, hosting Sacramento State (Jan. 16, 7 p.m.) and Utah State (Jan. 25, 1 p.m.). Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/1/9/womens-gymnastics-strong-foor-rotation-not-enough-in-loss-at-byu"
   },
   {
     "id": "sac-state-jan-16",
@@ -825,7 +833,9 @@
         }
       }
     ],
-    "attendance": "3,310"
+    "attendance": "3,310",
+    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito put up a pair of 9.900-plus scores on her way to a 39.500 in the all-around, helping the Oregon State Beavers defeat Sacramento State 196.375-193.675 at Gill Coliseum.\n\nEsposito started the meet with a 9.850 during the Beavers' vault rotation and followed it up with a new career high on bars, 9.900, before a 9.825 on beam set the stage for another 9.900-plus, earning a 9.925 for her floor exercise routine. Friday's floor score marked Esposito's second-consecutive week finishing with the meet's highest score on that event.\n\nKyanna Crabb led the entire meet off with a 9.875 in the first spot of OSU's vault lineup, earning a 9.900 from judge two and setting a new Oregon State career high in the process. Originally from Vancouver, Wash., Crabb has vaulted and completed an exhibition routine on floor in every single meet this season, and earned a 9.925 for her exhibition on Friday.\n\nEllie Weaver set a new career high in the meet's second rotation, earning a 9.950 on the uneven bars while anchoring the lineup, surpassing the 9.925 she set against Utah on March 11, 2023; the Battle Ground, Wash., native also competed on the beam, earning a 9.775, moving her beam average to 9.792 on the season while improving to a 9.833 average on the uneven bars.\n\nOlivia Buckner earned a pair of 9.875s on beam and floor, with the floor score setting a new personal best. Lauren Letzsch went 9.875 on beam while Savannah Miller earned a 9.875 on her floor routine for the second time in as many weeks.\n\nOSU's floor exercise lineup exceled against the Hornets, led off by Sophia Kaloudis' career-best 9.850 that was followed by a Paulina Vargas 9.825 and the 9.875s by Buckner and Miller; Esposito rounded out the rotation with her 9.925 to help the Beavers to a 49.350 rotation score, which is the highest on the season.\n\nThe Beavers improved in every single rotation, starting with a. 48.850 and progressing to a 49.050 bars score and 49.125 beam before floor exercise in the fourth.\n\nOregon State gymnastics stays home for its next meet, hosting Utah State next Sunday, Jan. 25. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/1/16/womens-gymnastics-espositos-39-500-helps-beavers-to-home-victory"
   },
   {
     "id": "utah-state-jan-25",
@@ -834,7 +844,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "W",
-    "osuScore": 196.600,
+    "osuScore": 196.6,
     "opponentScore": 196.075,
     "events": {
       "vault": {
@@ -952,7 +962,9 @@
         }
       }
     ],
-    "attendance": "3,651"
+    "attendance": "3,651",
+    "recap": "CORVALLIS, Ore. \u2013 Oregon State Gymnastics defeated the No. 23 Utah State Aggies on Sunday inside Gill Coliseum, posting a season-high 196.600 to secure a second-consecutive home victory.\n\nOSU's bars lineup was pivotal in the win, posting a season-high score for a single rotation with five scores tallying a 49.425, counting no lower than a 9.800 and posting a trio of 9.900-plus scores.\n\nFrancesca Caso , competing in the two spot, tied her career high with a 9.900 before Camryn Richardson and Ellie Weaver ended the rotation with back-to-back 9.925s; Sophia Esposito scored a 9.800 and Kaylee Cheek set a new season and career high thanks to a 9.875.\n\nFor Richardson, the 9.925 was a new career high and earned her first career event title thanks to Sunday's tie with Weaver, while Weaver has now won back-to-back event titles on the uneven bars after a 9.950 against Sacramento State last week. Esposito's bars routine helped fuel a second all-around title in as many weeks, also earning scores of 9.825 (VT), 9.850 (BB) and 9.750 (FX) to finish with a 39.225.\n\nOlivia Buckner also won her second event title of the year thanks to a 9.850 vault score, later adding a 9.800 during the team's third rotation on beam. Sunday's vault marked a new season high for the Riverton, Utah, native, who had earned a 9.800 at BYU two weeks ago.\n\nMia Heather's 9.900 on the balance beam was the meet's highest score on that event, earning a raucous response from Beaver faithful in attendance while surpassing the 9.825 scored last season in Tuscaloosa, Ala., at the NCAA Regional. The beam score also continued a strong start to Heather's collegiate career, having now hit on each of the seven routines she's completed as a Beav.\n\nPaulina Vargas led off the final rotation with a career-best 9.875 on floor while Reina Marchal earned her second 9.800-plus score in four routines this season, scoring a 9.825, while Savannah Miller tied her career high on that event thanks a 9.900 - her ninth time posting a 9.900.\n\nOregon State gymnastics is on the road for its next two meets, heading to face the Alabama Crimson Tide in Tuscaloosa next week and then to Boise, Idaho, on Feb. 6 before returning home Feb. 14 for another Pac-12 preview against Southern Utah, which is scheduled for Feb. 14 at 2 p.m. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/1/25/womens-gymnastics-beaver-bars-set-the-tone-in-victory-over-23rd-ranked-utah-state"
   },
   {
     "id": "alabama-jan-30",
@@ -962,7 +974,7 @@
     "isHome": false,
     "result": "L",
     "osuScore": 195.825,
-    "opponentScore": 197.450,
+    "opponentScore": 197.45,
     "events": {
       "vault": {
         "osu": 49.175,
@@ -1091,7 +1103,9 @@
           "beam": 9.7
         }
       }
-    ]
+    ],
+    "recap": "TUSCALOOSA, Ala. \u2013 Oregon State gymnastics was in action Friday night, posting a 195.825 in a road loss to No. 3 Alabama.\n\nThe Beaver beam lineup had a strong meet against the Tide, posting OSU's highest rotation score of any event, 49.100. Led off by Sophia Esposito's second-consecutive 9.850, Olivia Buckner earned a 9.825 to setup Kaylee Cheek , who tied a season and career high with a 9.850. Mia Heather and Lauren Letzch were both given 9.750s before Ellie Weaver anchored the lineup with a 9.825.\n\nCheek's performance came on the heels of a 9.850 on bars in rotation one, making it two-straight weeks with a 9.850 or better on that event after posting a 9.875 against No. 23 Utah State last week inside Gill Coliseum. Cheek, a freshman from Spanish Fork, Utah, has competed on bars and beam in every single meet this season.\n\nEsposito's strong bars score contributed to a 39.325 in the all-around, earning a pair of 9.800s on vault and bars before finishing her meet with a team-leading 9.875 on floor and the 9.850 beam score. The team-leader in total routines (18) and hits (18), Esposito has now posted a 9.800 or better in all but two of her routines this season.\n\nOlivia Buckner earned a pair of 9.825s on vault and beam, her second time earning a pair of 9.800-plus scores in as many weeks, while Savannah Miller posted a 9.850 during the team's floor rotation to make it four-consecutive weeks with a 9.850 or better on that event; Miller previously tied her career high with a 9.900 during last week's meet.\n\nAlabama posted a 197.450 to win Friday's competition.\n\nOregon State gymnastics stays on the road for its next meet, heading to Boise, Idaho, for a quad meet hosted by the Broncos that also features San Jos&eacute; State and UC Davis. Action at ExtraMile Arena is slated to begin at 6 p.m. PT / 7 p.m. MT.\n\nThe team returns home Feb. 14 for a Pac-12 preview against Southern Utah, which is scheduled for Feb. 14 at 2 p.m. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/1/30/womens-gymnastics-beaver-gymnastics-falls-to-no-3-alabama"
   },
   {
     "id": "boise-state-quad-boise-feb-6",
@@ -1100,8 +1114,8 @@
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "W",
-    "osuScore": 195.450,
-    "opponentScore": 195.350,
+    "osuScore": 195.45,
+    "opponentScore": 195.35,
     "quadMeet": true,
     "quadName": "Boise State Quad",
     "events": {
@@ -1263,16 +1277,18 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos&eacute; State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos&eacute; State, who used a huge vault score in the final rotation to take the meet.\n\nEllie Weaver's \u00a09.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from\u00a0 Camryn Richardson \u00a0and included both a 9.8500 from\u00a0 Kaylee Cheek \u00a0and 9.825 from\u00a0 Francesca Caso . For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\nLauren Letzsch \u00a0won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\nSophia Esposito \u00a0competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\nReina Marchal \u00a0earned a 9.825 for her floor routine while\u00a0 Savannah Miller \u00a0put up a career-high 9.800 while vaulting during the third rotation;\u00a0 Camryn Richardson \u00a0had another solid meet on vault (9.775) and bars (9.825).\n\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet"
   },
   {
     "id": "boise-state-quad-sjsu-feb-6",
     "date": "2026-02-06",
-    "opponent": "San José State",
+    "opponent": "San Jos\u00e9 State",
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 195.475,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1435,7 +1451,9 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos&eacute; State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos&eacute; State, who used a huge vault score in the final rotation to take the meet.\n\nEllie Weaver's \u00a09.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from\u00a0 Camryn Richardson \u00a0and included both a 9.8500 from\u00a0 Kaylee Cheek \u00a0and 9.825 from\u00a0 Francesca Caso . For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\nLauren Letzsch \u00a0won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\nSophia Esposito \u00a0competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\nReina Marchal \u00a0earned a 9.825 for her floor routine while\u00a0 Savannah Miller \u00a0put up a career-high 9.800 while vaulting during the third rotation;\u00a0 Camryn Richardson \u00a0had another solid meet on vault (9.775) and bars (9.825).\n\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet"
   },
   {
     "id": "boise-state-quad-ucdavis-feb-6",
@@ -1444,7 +1462,7 @@
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "W",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 193.025,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1607,7 +1625,9 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos&eacute; State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos&eacute; State, who used a huge vault score in the final rotation to take the meet.\n\nEllie Weaver's \u00a09.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from\u00a0 Camryn Richardson \u00a0and included both a 9.8500 from\u00a0 Kaylee Cheek \u00a0and 9.825 from\u00a0 Francesca Caso . For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\nLauren Letzsch \u00a0won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\nSophia Esposito \u00a0competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\nReina Marchal \u00a0earned a 9.825 for her floor routine while\u00a0 Savannah Miller \u00a0put up a career-high 9.800 while vaulting during the third rotation;\u00a0 Camryn Richardson \u00a0had another solid meet on vault (9.775) and bars (9.825).\n\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet"
   },
   {
     "id": "southern-utah-feb-14",
@@ -1616,7 +1636,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 196.300,
+    "osuScore": 196.3,
     "opponentScore": 196.825,
     "events": {
       "vault": {
@@ -1741,7 +1761,9 @@
         }
       }
     ],
-    "attendance": "3,954"
+    "attendance": "3,954",
+    "recap": "CORVALLIS, Ore. \u2013 Despite posting season-best marks on beam (49.350) and floor (49.400), Oregon State Gymnastics fell to the Southern Utah Flippin' Birds on Saturday, finishing with a 196.300 against a future Pac-12 opponent inside legendary Gill Coliseum.\n\nOlivia Buckner had a fantastic meet against SUU, finishing with scores of 9.875 (VT), 9.825 (BB) and 9.875 (FX). The vault score set a new season high and her 9.875 on floor tied a season and career high mark; Saturday's performance was also her first time with three or more 9.800-plus scores since the NCAA Tuscaloosa Regional Semifinal last spring.\n\nSophia Esposito's incredible performances in the all-around continued Saturday, finishing with a 39.450 that included bars and floor scores which tied a career high. The Melville, N.Y., native started her meet by vaulting to a 9.775 before earning her first 9.900 on the uneven bars, using that momentum to post a 9.825 for the beam team and rounding out the meet with another 9.900-plus, this time a 9.950 on floor.\n\nEsposito, who's now competed all-around in five-straight competitions, won event titles on bars and floor, and has now posted a 9.900 or better in consecutive weeks after earning a 9.900 for her floor routine in Boise.\n\nLauren Letzsch was also in the 9.900s on Saturday, earning a season high 9.925 for OSU's beam lineup that came within striking distance of her career high, which is 9.950. Letzsch, who entered the meet as the team-leader in average beam score, has now won three event titles this season that event.\n\nKaylee Cheek was also part of the 9.900 club, also earning her 9.900 on the balance beam. A true freshman from Spanish Fork, Utah, Cheek has competed on beam and bars in every meet this season and has earned a 9.850 or better for her beam routine on three different occasions.\n\nThat third rotation saw OSU score a season-high 49.350 on the beam, starting with a pair of 9.825s by Mia Heather and Buckner. After Cheek's 9.900, Ellie Weaver stepped up with a 9.875 to set the stage for Letzsch's 9.925 and an Esposito 9.825. Entering the meet as the 21 st -ranked beam lineup in the country, the rotation score bested the lineup's 49.125 score against Sacramento State on Jan. 16.\n\nOSU's floor group stole the show, however, putting up a 49.400 that counted no lower than a 9.825. Sophia Kaloudis was back in the lineup and earned that 9.825 before Buckner's 9.875 and a Reina Marchal 9.900 that set a new season and career high. Savannah Miller posted her fifth-consecutive 9.850 or better with an even 9.850 before Esposito's 9.950.\n\nSouthern Utah took the win with a 196.825.\n\nBeaver Gymnastics is on the road for its next meet, traveling to Denton, Texas, to compete against Texas Woman's and Kent State and Kent State in the TWU Tri Meet, returning home the following week to host Stanford Feb. 27. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/14/womens-gymnastics-season-highs-on-beam-and-floor-not-enough-in-loss-to-suu"
   },
   {
     "id": "twu-quad-kent-feb-22",
@@ -1912,7 +1934,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\nAfter an early fall, OSU's bars lineup\u00a0responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson , who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet"
   },
   {
     "id": "twu-quad-asu-feb-22",
@@ -1922,7 +1946,7 @@
     "isHome": false,
     "result": "W",
     "osuScore": 195.775,
-    "opponentScore": 195.550,
+    "opponentScore": 195.55,
     "quadMeet": true,
     "quadName": "TWU Quad",
     "events": {
@@ -2083,7 +2107,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\nAfter an early fall, OSU's bars lineup\u00a0responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson , who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet"
   },
   {
     "id": "twu-quad-twu-feb-22",
@@ -2254,7 +2280,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\nAfter an early fall, OSU's bars lineup\u00a0responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson , who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .",
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet"
   },
   {
     "id": "stanford-feb-27",
@@ -2263,8 +2291,8 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 197.250,
-    "opponentScore": 198.150,
+    "osuScore": 197.25,
+    "opponentScore": 198.15,
     "events": {
       "vault": {
         "osu": 49.3,
@@ -2393,7 +2421,9 @@
         }
       }
     ],
-    "attendance": "3,617"
+    "attendance": "3,617",
+    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito earned four 9.900 or better scores on her way to a career-high 39.700 in the all-around as Oregon State Gymnastics' season-best 197.250 wasn't enough, falling to No. 10 Stanford's 198.150 inside legendary Gill Coliseum.\n\nEsposito bested her previous career high of 39.525 thanks to a pair of career highs on vault (9.950) and beam (9.950) to go with 9.9.00s on bars and floor. The Melville, N.Y., native has been tremendous as a junior in 2026, hitting on each of her 34 routines this season and has now posted a 9.900 or better on at least one event in three of her last four meets.\n\nOlivia Buckner had another fantastic performance, vaulting her way to a 9.900 before adding a 9.825 on the beam and 9.875 for her floor routine. With her vault, Buckner has now tallied a 9.850 or better on that event in each of the last three competitions, while the floor score tied a career high.\n\nBuckner and Esposito were both part of a strong showing for the vault lineup, who set a season-high rotation score with a 49.300. Led off by Reina Marchal's 9.775, Savannah Miller was given a 9.800 before Buckner and Esposito went back-to-back with their 9.900 and 9.950; Katie Rude finished the Beavers' scoring with a 9.875 that set a new career high.\n\nEllie Weaver led the way during OSU's bars rotation with a 9.925, her second-straight week with a 9.900 or better on that event, while the rotation also featured Esposito's 9.900, a Taylor DeVries 9.825 and Francesca Caso 9.800.\n\nThe Beaver beam lineup also set a new season-best rotation score, counting a pair of 9.900 or better scores and no lower than a 9.800. Led off by a Mia Heather 9.875 that was followed immediately by Buckner's 9.825 and a Kaylee Cheek 9.800, Lauren Letzsch posted her second 9.925 in the last three meets before Esposito's 9.950 to round out the team's 49.375 combined score on beam.\n\nSophia Kaloudis was back in the floor lineup and led it off with a career high-tying 9.850 before Buckner, Marchal and Miller rattled off three-straight 9.875s and Esposito's 9.900.\n\nFor Marchal, the 9.875 comes on the heels of a 9.850 last week in Texas and 9.900 the weekend before, while Miller's makes it six 9.850 or better scores in her last seven appearances.\n\nOregon State gymnastics is back on the road next weekend, heading to Logan, Utah, to face Utah State, returning home to face Denver on March 14 inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/2/27/womens-gymnastics-espositos-career-night-leads-season-high-score"
   },
   {
     "id": "utah-state-mar-6",
@@ -2402,8 +2432,8 @@
     "location": "Dee Glen Smith Spectrum, Logan, UT",
     "isHome": false,
     "result": "L",
-    "osuScore": 196.150,
-    "opponentScore": 196.950,
+    "osuScore": 196.15,
+    "opponentScore": 196.95,
     "events": {
       "vault": {
         "osu": 48.975,
@@ -2524,6 +2554,8 @@
           "beam": 9.8
         }
       }
-    ]
+    ],
+    "recap": "LOGAN, Utah \u2013 Oregon State gymnastics fell to future Pac-12 opponent Utah State Friday night, posting a 196.150 at the Dee Glen Smith Spectrum.\n\nThe Beaver floor lineup led the team's scoring with a 49.275 in the third rotation. Sophia Kaloudis and Reina Marchal led off with a pair of 9.800s that were followed by a pair of 9.850s from Olivia Buckner and Reina Marchal , which was immediately followed by Savannah Miller , who earned a 9.875, and Sophia Esposito , who was given the Beavers' only 9.900 of the meet.\n\nDeVries set a new career-high with her 9.800 and Buckner made it three meets in four weeks with a 9.850 or better on that event. Marchal's 9.850 was her fourth-consecutive 9.850 or better and Esposito has now earned a 9.900 in back-to-back weeks.\n\nSavannah Miller set a new career high on bars, leading off the lineup with a 9.850, setting the stage for a rotation that counted no lower than a 9.800. Following Miller's routine, Kaloudis earned a 9.800 before Francesca Caso and Esposito rattled off back-to-back 9.850s; Ellie Weaver finished the scoring with a 9.800.\n\nBuckner added a 9.875 on vault and 9.775 on beam, while Esposito vaulted her way to a 9.850 to cap a 39.275 in the all-around.\n\nUtah State finished the meet with a 196.650 to claim victory.\n\nOregon State gymnastics returns home to face Denver on March 14 inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix .\n\nOUR MISSION:\n\nOregon State Athletics strives to\u00a0 B uild\u00a0 E xcellent\u00a0 A uthentic\u00a0 V isionary\u00a0 S tudent- A thletes (Go BEAVS).",
+    "recapUrl": "https://osubeavers.com/news/2026/3/6/womens-gymnastics-beaver-gymnastics-falls-to-utah-state"
   }
 ]

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -155,7 +155,7 @@ main {
   max-width: 1200px;
   margin: 0 auto;
   padding: 1rem;
-  padding-bottom: 80px; /* space for bottom nav */
+  padding-bottom: 80px;
 }
 
 .view {
@@ -165,6 +165,35 @@ main {
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+/* ===== Breadcrumbs ===== */
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.breadcrumb-link {
+  color: var(--orange);
+  text-decoration: none;
+  transition: opacity var(--transition);
+}
+
+.breadcrumb-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.breadcrumb-sep {
+  color: var(--text-muted);
+}
+
+.breadcrumb-current {
+  color: var(--text-muted);
 }
 
 /* ===== Hero Banner ===== */
@@ -412,6 +441,16 @@ main {
   color: var(--text-muted);
 }
 
+.event-bar-name.clickable {
+  color: var(--orange);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.event-bar-name.clickable:hover {
+  text-decoration: underline;
+}
+
 .event-bar-track {
   height: 6px;
   background: var(--border);
@@ -424,6 +463,89 @@ main {
   border-radius: 3px;
   transition: width 0.8s ease;
   background: var(--orange);
+}
+
+/* ===== Cross-linking styles ===== */
+.athlete-link {
+  color: var(--text);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.athlete-link:hover {
+  color: var(--orange);
+  text-decoration: underline;
+}
+
+.event-title-link {
+  color: var(--orange);
+  text-decoration: none;
+  transition: opacity var(--transition);
+}
+
+.event-title-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.score-link {
+  text-decoration: none;
+  transition: opacity var(--transition);
+}
+
+.score-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.opponent-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 2px dotted var(--orange);
+  transition: all var(--transition);
+}
+
+.opponent-link:hover {
+  color: var(--orange);
+  border-bottom-style: solid;
+}
+
+.score-history-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.score-history-link:hover {
+  color: var(--orange);
+  text-decoration: underline;
+}
+
+.pb-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.pb-link:hover .stat-value {
+  text-decoration: underline;
+}
+
+.lb-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: block;
+}
+
+.lb-context {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  display: block;
+}
+
+.lb-context:hover {
+  color: var(--orange);
+  text-decoration: underline;
 }
 
 /* ===== Meet Detail ===== */
@@ -498,6 +620,71 @@ main {
   font-family: 'Oswald', sans-serif;
   font-weight: 500;
   text-align: right;
+}
+
+/* ===== Meet Recap ===== */
+.recap-card {
+  border-left-color: var(--orange);
+}
+
+.recap-body {
+  max-width: 720px;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.recap-lede {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 1rem;
+  line-height: 1.7;
+}
+
+.recap-text {
+  color: var(--text);
+  margin-bottom: 0.75rem;
+  opacity: 0.9;
+  line-height: 1.7;
+}
+
+.recap-collapsed {
+  animation: fadeIn 0.3s ease;
+}
+
+.recap-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--orange);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  margin-top: 0.5rem;
+  transition: all var(--transition);
+}
+
+.recap-toggle:hover {
+  background: rgba(215, 63, 9, 0.1);
+  border-color: var(--orange);
+}
+
+.recap-attribution {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+.recap-attribution a {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.recap-attribution a:hover {
+  color: var(--orange);
 }
 
 /* ===== Gymnast Search ===== */
@@ -761,16 +948,6 @@ main {
   min-width: 0;
 }
 
-.lb-name {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.lb-context {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
 .lb-score {
   font-family: 'Oswald', sans-serif;
   font-size: 1.25rem;
@@ -846,6 +1023,16 @@ main {
   
   .hero-subtitle {
     font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .recap-body {
+    font-size: 15px;
+  }
+
+  .recap-lede {
+    font-size: 1rem;
   }
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,13 +26,63 @@
     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'long', day: 'numeric', year: 'numeric' });
   }
 
+  function slugify(name) {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+  }
+
+  function getMonth(dateStr) {
+    const d = new Date(dateStr + 'T12:00:00');
+    return d.toLocaleDateString('en-US', { month: 'long' }).toLowerCase();
+  }
+
+  // ===== Hash Routing =====
+  function navigate(hash, replace) {
+    if (replace) {
+      history.replaceState(null, '', '#' + hash);
+    } else {
+      history.pushState(null, '', '#' + hash);
+    }
+    routeFromHash();
+  }
+
+  function routeFromHash() {
+    const hash = location.hash.slice(1) || 'season';
+    const [path, queryStr] = hash.split('?');
+    const params = new URLSearchParams(queryStr || '');
+
+    if (path === 'season') {
+      const filter = params.get('filter');
+      if (filter) currentFilter = filter;
+      showView('season', true);
+    } else if (path.startsWith('meet/')) {
+      const meetId = path.slice(5);
+      showMeetDetail(meetId, true);
+    } else if (path.startsWith('gymnast/')) {
+      const slug = path.slice(8);
+      showGymnastProfileBySlug(slug, true);
+    } else if (path.startsWith('leaderboard/')) {
+      const event = path.slice(12);
+      showView('leaderboards', true);
+      renderLeaderboard(event);
+    } else if (path === 'gymnasts') {
+      showView('gymnasts', true);
+    } else if (path === 'leaderboards') {
+      showView('leaderboards', true);
+    } else if (path.startsWith('opponent/')) {
+      const oppSlug = path.slice(9);
+      showOpponentMeets(oppSlug, true);
+    } else {
+      showView('season', true);
+    }
+  }
+
   // ===== Data Loading =====
   async function loadData() {
     try {
       const res = await fetch('/api/meets');
       meets = await res.json();
       document.getElementById('loading').style.display = 'none';
-      showView('season');
+      routeFromHash();
     } catch (err) {
       document.getElementById('loading').innerHTML =
         '<div class="empty-state"><div class="empty-icon">😕</div><p class="empty-text">Failed to load data. Is the server running?</p></div>';
@@ -40,7 +90,7 @@
   }
 
   // ===== Navigation =====
-  function showView(view) {
+  function showView(view, fromRoute) {
     currentView = view;
     document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
     document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
@@ -50,13 +100,25 @@
     if (el) {
       el.style.display = 'block';
       el.style.animation = 'none';
-      el.offsetHeight; // trigger reflow
+      el.offsetHeight;
       el.style.animation = '';
     }
 
     if (view === 'season') renderSeason();
     else if (view === 'gymnasts') renderGymnasts();
     else if (view === 'leaderboards') renderLeaderboard('vault');
+
+    if (!fromRoute) {
+      navigate(view);
+    }
+  }
+
+  // ===== Breadcrumbs =====
+  function renderBreadcrumbs(crumbs) {
+    return `<nav class="breadcrumbs">${crumbs.map((c, i) => {
+      if (i === crumbs.length - 1) return `<span class="breadcrumb-current">${c.label}</span>`;
+      return `<a href="#${c.hash}" class="breadcrumb-link">${c.label}</a>`;
+    }).join('<span class="breadcrumb-sep">›</span>')}</nav>`;
   }
 
   // ===== Season Overview =====
@@ -78,9 +140,18 @@
 
   function renderScoreTrend() {
     const container = document.getElementById('scoreTrend');
+    // Deduplicate by date for trend (quad meets share a date/score)
+    const seen = new Set();
+    const uniqueMeets = meets.filter(m => {
+      const key = m.date;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
     const w = 700, h = 180;
     const pad = { top: 20, right: 20, bottom: 35, left: 50 };
-    const scores = meets.map(m => m.osuScore);
+    const scores = uniqueMeets.map(m => m.osuScore);
     const min = Math.min(...scores) - 0.5;
     const max = Math.max(...scores) + 0.5;
     const xScale = i => pad.left + (i / (scores.length - 1)) * (w - pad.left - pad.right);
@@ -89,16 +160,13 @@
     let pathD = scores.map((s, i) => `${i === 0 ? 'M' : 'L'}${xScale(i).toFixed(1)},${yScale(s).toFixed(1)}`).join(' ');
 
     let dots = scores.map((s, i) => {
-      const color = meets[i].result === 'W' ? '#2ecc71' : '#e74c3c';
-      return `<circle cx="${xScale(i).toFixed(1)}" cy="${yScale(s).toFixed(1)}" r="5" fill="${color}" stroke="var(--dark)" stroke-width="2">
-        <title>${formatDate(meets[i].date)}: ${s.toFixed(3)} (${meets[i].result})</title>
+      const color = uniqueMeets[i].result === 'W' ? '#2ecc71' : '#e74c3c';
+      return `<circle cx="${xScale(i).toFixed(1)}" cy="${yScale(s).toFixed(1)}" r="5" fill="${color}" stroke="var(--dark)" stroke-width="2" style="cursor:pointer" data-meet-id="${uniqueMeets[i].id}">
+        <title>${formatDate(uniqueMeets[i].date)}: ${s.toFixed(3)} (${uniqueMeets[i].result})</title>
       </circle>`;
     }).join('');
 
-    // Y-axis labels
-    const yTicks = 5;
-    let yLabels = '';
-    let yGridLines = '';
+    let yTicks = 5, yLabels = '', yGridLines = '';
     for (let i = 0; i <= yTicks; i++) {
       const v = min + (i / yTicks) * (max - min);
       const y = yScale(v);
@@ -106,8 +174,7 @@
       yGridLines += `<line x1="${pad.left}" y1="${y}" x2="${w - pad.right}" y2="${y}" stroke="#333" stroke-width="0.5"/>`;
     }
 
-    // X-axis labels
-    let xLabels = meets.map((m, i) => {
+    let xLabels = uniqueMeets.map((m, i) => {
       const x = xScale(i);
       return `<text x="${x}" y="${h - 5}" text-anchor="middle" fill="#999" font-size="9" font-family="Inter">${formatDate(m.date)}</text>`;
     }).join('');
@@ -132,12 +199,16 @@
       return m.result === currentFilter;
     });
 
+    // Update filter button active state
+    document.querySelectorAll('.filter-btn').forEach(b => {
+      b.classList.toggle('active', b.dataset.filter === currentFilter);
+    });
+
     if (filtered.length === 0) {
       grid.innerHTML = '<div class="empty-state"><div class="empty-icon">🔍</div><p class="empty-text">No meets match this filter.</p></div>';
       return;
     }
 
-    // Group quad meets together; non-quad meets appear as-is
     const rendered = [];
     const seenQuads = new Set();
 
@@ -145,7 +216,6 @@
       if (m.quadMeet && m.quadName) {
         if (!seenQuads.has(m.quadName)) {
           seenQuads.add(m.quadName);
-          // Gather all matchups for this quad
           const quadMeets = filtered.filter(q => q.quadName === m.quadName);
           rendered.push(renderQuadGroup(quadMeets));
         }
@@ -156,7 +226,6 @@
 
     grid.innerHTML = rendered.join('');
 
-    // Animate bars after render
     requestAnimationFrame(() => {
       grid.querySelectorAll('.event-bar-fill').forEach(bar => {
         const w = bar.style.width;
@@ -172,7 +241,7 @@
       return `
         <div class="event-bar-item">
           <div class="event-bar-label">
-            <span>${EVENT_SHORT[e]}</span>
+            <span class="event-bar-name clickable" data-event="${e}">${EVENT_SHORT[e]}</span>
             <span>${m.events[e].osu.toFixed(3)}</span>
           </div>
           <div class="event-bar-track">
@@ -186,8 +255,8 @@
         <div class="meet-header">
           <div>
             <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''}</div>
-            <div class="meet-date">${formatDateLong(m.date)}</div>
-            <div class="meet-location">${m.location}</div>
+            <div class="meet-date clickable" data-date="${m.date}">${formatDateLong(m.date)}</div>
+            <div class="meet-location clickable" data-location="${m.isHome ? 'home' : 'away'}">${m.location}</div>
           </div>
           <span class="badge badge-${m.result.toLowerCase()}">${m.result}</span>
         </div>
@@ -240,15 +309,25 @@
   }
 
   // ===== Meet Detail =====
-  function showMeetDetail(meetId) {
+  function showMeetDetail(meetId, fromRoute) {
     const meet = meets.find(m => m.id === meetId);
     if (!meet) return;
 
+    currentView = 'meet';
     document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
+    document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
     const view = document.getElementById('view-meet');
     view.style.display = 'block';
 
+    if (!fromRoute) navigate('meet/' + meetId);
+
     const content = document.getElementById('meetDetailContent');
+
+    // Breadcrumbs
+    const breadcrumbs = renderBreadcrumbs([
+      { label: 'Season', hash: 'season' },
+      { label: `${meet.opponent} ${formatDate(meet.date)}`, hash: 'meet/' + meetId }
+    ]);
 
     // Quad meet teams table
     let teamsTable = '';
@@ -271,7 +350,32 @@
         </div>`;
     }
 
-    // Event detail cards with athlete lineups
+    // Recap section
+    let recapSection = '';
+    if (meet.recap) {
+      const paragraphs = meet.recap.split('\n\n').filter(p => p.trim());
+      const firstPara = paragraphs[0] || '';
+      const restParas = paragraphs.slice(1);
+      const hasMore = restParas.length > 2;
+
+      recapSection = `
+        <div class="section-card recap-card">
+          <h2 class="section-title">📰 Meet Recap</h2>
+          <div class="recap-body">
+            <p class="recap-lede">${firstPara}</p>
+            ${restParas.slice(0, 2).map(p => `<p class="recap-text">${p}</p>`).join('')}
+            ${hasMore ? `
+              <div class="recap-collapsed" id="recapMore" style="display:none;">
+                ${restParas.slice(2).map(p => `<p class="recap-text">${p}</p>`).join('')}
+              </div>
+              <button class="recap-toggle" id="recapToggle">Read more ▾</button>
+            ` : ''}
+          </div>
+          ${meet.recapUrl ? `<div class="recap-attribution"><a href="${meet.recapUrl}" target="_blank" rel="noopener">Source: Oregon State Athletics ↗</a></div>` : ''}
+        </div>`;
+    }
+
+    // Event detail cards with clickable athlete names and event names
     const eventCards = ['vault', 'bars', 'beam', 'floor'].map(event => {
       const eventAthletes = meet.athletes
         .filter(a => a.scores[event] !== undefined)
@@ -280,7 +384,7 @@
       const rows = eventAthletes.map((a, i) => `
         <tr>
           <td>${i + 1}</td>
-          <td>${a.name}</td>
+          <td><a href="#gymnast/${slugify(a.name)}" class="athlete-link">${a.name}</a></td>
           <td class="score-cell">${a.scores[event].toFixed(3)}</td>
         </tr>`).join('');
 
@@ -290,9 +394,9 @@
 
       return `
         <div class="detail-event-card">
-          <div class="detail-event-title">${EVENT_NAMES[event]}</div>
+          <div class="detail-event-title"><a href="#leaderboard/${event}" class="event-title-link">${EVENT_NAMES[event]}</a></div>
           <div style="display:flex;justify-content:space-between;margin-bottom:0.5rem;">
-            <span style="color:var(--orange);font-family:Oswald;font-weight:600;">${osuScore.toFixed(3)}</span>
+            <a href="#leaderboard/${event}" class="score-link" style="color:var(--orange);font-family:Oswald;font-weight:600;">${osuScore.toFixed(3)}</a>
             <span style="color:var(--text-muted);font-size:0.85rem;">vs ${oppScore.toFixed(3)}</span>
           </div>
           <div class="event-bar-track" style="margin-bottom:0.75rem;">
@@ -305,11 +409,15 @@
         </div>`;
     }).join('');
 
+    // Opponent link
+    const opponentSlug = slugify(meet.opponent);
+
     content.innerHTML = `
+      ${breadcrumbs}
       <div class="detail-hero">
         <div class="meet-header">
           <div>
-            <div class="meet-opponent" style="font-size:1.5rem;">vs ${meet.opponent}</div>
+            <div class="meet-opponent" style="font-size:1.5rem;">vs <a href="#opponent/${opponentSlug}" class="opponent-link">${meet.opponent}</a></div>
             <div class="meet-date">${formatDateLong(meet.date)}</div>
             <div class="meet-location">${meet.location}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
           </div>
@@ -318,12 +426,55 @@
         <div class="meet-scores" style="margin-top:1rem;">
           <div class="team-score"><div class="team-name">Oregon State</div><div class="score score-osu" style="font-size:2rem;">${meet.osuScore.toFixed(3)}</div></div>
           <div class="score-vs">vs</div>
-          <div class="team-score"><div class="team-name">Opponent</div><div class="score" style="font-size:2rem;">${meet.opponentScore.toFixed(3)}</div></div>
+          <div class="team-score"><div class="team-name"><a href="#opponent/${opponentSlug}" class="opponent-link">${meet.opponent}</a></div><div class="score" style="font-size:2rem;">${meet.opponentScore.toFixed(3)}</div></div>
         </div>
       </div>
       ${teamsTable}
+      ${recapSection}
       <h2 class="section-title" style="margin-bottom:1rem;">Event Breakdown</h2>
       <div class="detail-event-grid">${eventCards}</div>
+    `;
+
+    // Recap toggle
+    const toggleBtn = document.getElementById('recapToggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        const more = document.getElementById('recapMore');
+        const expanded = more.style.display !== 'none';
+        more.style.display = expanded ? 'none' : 'block';
+        toggleBtn.textContent = expanded ? 'Read more ▾' : 'Show less ▴';
+      });
+    }
+  }
+
+  // ===== Opponent Meets View =====
+  function showOpponentMeets(oppSlug, fromRoute) {
+    const oppMeets = meets.filter(m => slugify(m.opponent) === oppSlug);
+    if (oppMeets.length === 0) { navigate('season'); return; }
+
+    currentView = 'opponent';
+    document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
+    document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
+    const view = document.getElementById('view-meet');
+    view.style.display = 'block';
+
+    if (!fromRoute) navigate('opponent/' + oppSlug);
+
+    const oppName = oppMeets[0].opponent;
+    const breadcrumbs = renderBreadcrumbs([
+      { label: 'Season', hash: 'season' },
+      { label: `vs ${oppName}`, hash: 'opponent/' + oppSlug }
+    ]);
+
+    const cards = oppMeets.map(m => renderMeetCard(m)).join('');
+
+    document.getElementById('meetDetailContent').innerHTML = `
+      ${breadcrumbs}
+      <div class="section-card" style="margin-bottom:1.5rem;">
+        <h2 class="section-title">All Meets vs ${oppName}</h2>
+        <p style="color:var(--text-muted);font-size:0.9rem;">${oppMeets.length} meet${oppMeets.length > 1 ? 's' : ''} this season</p>
+      </div>
+      <div class="meets-grid">${cards}</div>
     `;
   }
 
@@ -333,7 +484,7 @@
     meets.forEach(meet => {
       meet.athletes.forEach(a => {
         if (!profiles[a.name]) {
-          profiles[a.name] = { name: a.name, meets: [], events: new Set() };
+          profiles[a.name] = { name: a.name, slug: slugify(a.name), meets: [], events: new Set() };
         }
         const entry = { meetId: meet.id, date: meet.date, opponent: meet.opponent, scores: { ...a.scores } };
         profiles[a.name].meets.push(entry);
@@ -343,19 +494,20 @@
       });
     });
 
-    // Compute averages and bests
     Object.values(profiles).forEach(p => {
       p.averages = {};
       p.bests = {};
+      p.bestMeets = {};
       p.eventsList = Array.from(p.events);
 
       ['vault', 'bars', 'beam', 'floor', 'aa'].forEach(event => {
-        const scores = p.meets
-          .filter(m => m.scores[event] !== undefined)
-          .map(m => m.scores[event]);
+        const entries = p.meets.filter(m => m.scores[event] !== undefined);
+        const scores = entries.map(m => m.scores[event]);
         if (scores.length > 0) {
           p.averages[event] = scores.reduce((a, b) => a + b, 0) / scores.length;
           p.bests[event] = Math.max(...scores);
+          const bestIdx = scores.indexOf(p.bests[event]);
+          p.bestMeets[event] = entries[bestIdx].meetId;
         }
       });
 
@@ -390,7 +542,7 @@
       }).join('');
 
       return `
-        <div class="gymnast-card" data-gymnast="${p.name}">
+        <div class="gymnast-card" data-gymnast="${p.name}" data-slug="${p.slug}">
           <div class="gymnast-name">${p.name}</div>
           <div class="gymnast-events">${eventBadges}</div>
           <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">${p.totalMeets} meets</div>
@@ -399,30 +551,54 @@
     }).join('');
   }
 
-  function showGymnastProfile(name) {
+  function showGymnastProfileBySlug(slug, fromRoute) {
+    const profiles = getGymnastProfiles();
+    const p = profiles.find(pr => pr.slug === slug);
+    if (!p) return;
+    showGymnastProfile(p.name, fromRoute);
+  }
+
+  function showGymnastProfile(name, fromRoute) {
     const profiles = getGymnastProfiles();
     const p = profiles.find(pr => pr.name === name);
     if (!p) return;
+
+    currentView = 'gymnast';
+
+    if (!fromRoute) navigate('gymnast/' + p.slug);
+
+    // Hide cards, show gymnasts view
+    document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
+    document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
+    document.querySelectorAll('[data-view="gymnasts"]').forEach(l => l.classList.add('active'));
+    document.getElementById('view-gymnasts').style.display = 'block';
 
     document.getElementById('gymnastCards').style.display = 'none';
     const detail = document.getElementById('gymnastDetail');
     detail.style.display = 'block';
 
+    // Breadcrumbs
+    const breadcrumbs = renderBreadcrumbs([
+      { label: 'Gymnasts', hash: 'gymnasts' },
+      { label: p.name, hash: 'gymnast/' + p.slug }
+    ]);
+
     // Stats grid
     const statsGrid = ['vault', 'bars', 'beam', 'floor'].map(event => {
       if (!p.averages[event]) return '';
+      const bestMeetId = p.bestMeets[event];
       return `
         <div class="profile-stat">
           <div class="stat-value" style="color:var(--orange)">${p.averages[event].toFixed(3)}</div>
           <div class="stat-label">${EVENT_NAMES[event]} Avg</div>
         </div>
         <div class="profile-stat">
-          <div class="stat-value">${p.bests[event].toFixed(3)}</div>
+          <a href="#meet/${bestMeetId}" class="pb-link"><div class="stat-value">${p.bests[event].toFixed(3)} ★</div></a>
           <div class="stat-label">${EVENT_NAMES[event]} Best</div>
         </div>`;
     }).join('');
 
-    // Sparklines per event
+    // Sparklines
     const sparklines = ['vault', 'bars', 'beam', 'floor'].map(event => {
       const eventMeets = p.meets.filter(m => m.scores[event] !== undefined);
       if (eventMeets.length < 2) return '';
@@ -435,20 +611,20 @@
         </div>`;
     }).join('');
 
-    // Meet history table
+    // Meet history table with clickable scores and meet links
     const historyRows = p.meets.map(m => {
       const cells = ['vault', 'bars', 'beam', 'floor'].map(e => {
         if (m.scores[e] === undefined) return '<td style="color:var(--text-muted)">—</td>';
         const isBest = p.bests[e] === m.scores[e];
-        return `<td class="${isBest ? 'personal-best' : ''}">${m.scores[e].toFixed(3)}${isBest ? ' ★' : ''}</td>`;
+        return `<td class="${isBest ? 'personal-best' : ''}"><a href="#meet/${m.meetId}" class="score-history-link">${m.scores[e].toFixed(3)}${isBest ? ' ★' : ''}</a></td>`;
       }).join('');
-      const aa = m.scores.aa ? `<td>${m.scores.aa.toFixed(3)}</td>` : '<td style="color:var(--text-muted)">—</td>';
-      return `<tr><td>${formatDate(m.date)}</td><td>${m.opponent}</td>${cells}${aa}</tr>`;
+      const aa = m.scores.aa ? `<td><a href="#meet/${m.meetId}" class="score-history-link">${m.scores.aa.toFixed(3)}</a></td>` : '<td style="color:var(--text-muted)">—</td>';
+      return `<tr><td><a href="#meet/${m.meetId}" class="score-history-link">${formatDate(m.date)}</a></td><td><a href="#meet/${m.meetId}" class="score-history-link">${m.opponent}</a></td>${cells}${aa}</tr>`;
     }).join('');
 
     detail.innerHTML = `
       <div class="gymnast-profile">
-        <button class="back-btn" id="backToGymnasts">← Back to Gymnasts</button>
+        ${breadcrumbs}
         <div class="profile-header">
           <div class="profile-name">${p.name}</div>
           <div style="color:var(--text-muted);margin-top:0.25rem;">${p.totalMeets} meets competed • Oregon State</div>
@@ -465,11 +641,6 @@
           </div>
         </div>
       </div>`;
-
-    document.getElementById('backToGymnasts').addEventListener('click', () => {
-      detail.style.display = 'none';
-      document.getElementById('gymnastCards').style.display = 'grid';
-    });
   }
 
   function createSparkline(scores, labels) {
@@ -507,6 +678,7 @@
         if (a.scores[event] !== undefined) {
           allScores.push({
             name: a.name,
+            slug: slugify(a.name),
             score: a.scores[event],
             meetDate: meet.date,
             opponent: meet.opponent,
@@ -529,8 +701,8 @@
       <div class="leaderboard-item">
         <div class="lb-rank ${i < 3 ? 'top-3' : ''}">${i + 1}</div>
         <div class="lb-info">
-          <div class="lb-name">${s.name}</div>
-          <div class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}</div>
+          <a href="#gymnast/${s.slug}" class="lb-name athlete-link">${s.name}</a>
+          <a href="#meet/${s.meetId}" class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}</a>
         </div>
         <div class="lb-score">${s.score.toFixed(3)}</div>
       </div>`).join('');
@@ -540,11 +712,16 @@
   document.addEventListener('DOMContentLoaded', () => {
     loadData();
 
-    // Navigation
+    // Hash navigation
+    window.addEventListener('popstate', routeFromHash);
+
+    // Navigation links
     document.querySelectorAll('[data-view]').forEach(link => {
       link.addEventListener('click', e => {
         e.preventDefault();
-        showView(link.dataset.view);
+        const view = link.dataset.view;
+        currentFilter = 'all';
+        navigate(view);
       });
     });
 
@@ -554,18 +731,38 @@
         currentFilter = btn.dataset.filter;
         document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
+        if (currentFilter === 'all') {
+          navigate('season', true);
+        } else {
+          navigate('season?filter=' + currentFilter, true);
+        }
         renderMeetCards();
       });
     });
 
-    // Meet card click
+    // Meet card click (delegated)
     document.getElementById('meetsGrid').addEventListener('click', e => {
+      // Handle event name clicks on cards
+      const eventName = e.target.closest('.event-bar-name');
+      if (eventName) {
+        e.stopPropagation();
+        navigate('leaderboard/' + eventName.dataset.event);
+        return;
+      }
+
       const card = e.target.closest('.meet-card');
-      if (card) showMeetDetail(card.dataset.meetId);
+      if (card) navigate('meet/' + card.dataset.meetId);
     });
 
-    // Back button
-    document.getElementById('backToSeason').addEventListener('click', () => showView('season'));
+    // Score trend chart click
+    document.getElementById('scoreTrend').addEventListener('click', e => {
+      if (e.target.tagName === 'circle' && e.target.dataset.meetId) {
+        navigate('meet/' + e.target.dataset.meetId);
+      }
+    });
+
+    // Back to season
+    document.getElementById('backToSeason').addEventListener('click', () => navigate('season'));
 
     // Gymnast search
     document.getElementById('gymnastSearch').addEventListener('input', e => {
@@ -575,13 +772,17 @@
     // Gymnast card click
     document.getElementById('gymnastCards').addEventListener('click', e => {
       const card = e.target.closest('.gymnast-card');
-      if (card) showGymnastProfile(card.dataset.gymnast);
+      if (card) navigate('gymnast/' + card.dataset.slug);
     });
 
     // Event tabs
     document.getElementById('eventTabs').addEventListener('click', e => {
       const tab = e.target.closest('.event-tab');
-      if (tab) renderLeaderboard(tab.dataset.event);
+      if (tab) {
+        const event = tab.dataset.event;
+        navigate('leaderboard/' + event, true);
+        renderLeaderboard(event);
+      }
     });
   });
 })();

--- a/scripts/fetch_recaps.py
+++ b/scripts/fetch_recaps.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Fetch meet recap articles from osubeavers.com and embed them into meets.json.
+"""
+
+import json
+import os
+import re
+import urllib.request
+
+RECAP_URLS = {
+    "best-of-west": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad",
+    "byu-jan-9": "https://osubeavers.com/news/2026/1/9/womens-gymnastics-strong-foor-rotation-not-enough-in-loss-at-byu",
+    "sac-state-jan-16": "https://osubeavers.com/news/2026/1/16/womens-gymnastics-espositos-39-500-helps-beavers-to-home-victory",
+    "utah-state-jan-25": "https://osubeavers.com/news/2026/1/25/womens-gymnastics-beaver-bars-set-the-tone-in-victory-over-23rd-ranked-utah-state",
+    "alabama-jan-30": "https://osubeavers.com/news/2026/1/30/womens-gymnastics-beaver-gymnastics-falls-to-no-3-alabama",
+    "boise-state-quad": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet",
+    "southern-utah-feb-14": "https://osubeavers.com/news/2026/2/14/womens-gymnastics-season-highs-on-beam-and-floor-not-enough-in-loss-to-suu",
+    "twu-quad": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet",
+    "stanford-feb-27": "https://osubeavers.com/news/2026/2/27/womens-gymnastics-espositos-career-night-leads-season-high-score",
+    "utah-state-mar-6": "https://osubeavers.com/news/2026/3/6/womens-gymnastics-beaver-gymnastics-falls-to-utah-state",
+}
+
+# Map meet IDs to their recap key (quad meets share a recap)
+MEET_ID_TO_RECAP = {
+    "best-of-west-washington-jan-3": "best-of-west",
+    "best-of-west-california-jan-3": "best-of-west",
+    "best-of-west-ucla-jan-3": "best-of-west",
+    "byu-jan-9": "byu-jan-9",
+    "sac-state-jan-16": "sac-state-jan-16",
+    "utah-state-jan-25": "utah-state-jan-25",
+    "alabama-jan-30": "alabama-jan-30",
+    "boise-state-quad-boise-feb-6": "boise-state-quad",
+    "boise-state-quad-sjsu-feb-6": "boise-state-quad",
+    "boise-state-quad-ucdavis-feb-6": "boise-state-quad",
+    "boise-state-quad-san-jose-state-feb-6": "boise-state-quad",
+    "southern-utah-feb-14": "southern-utah-feb-14",
+    "twu-quad-kent-feb-22": "twu-quad",
+    "twu-quad-asu-feb-22": "twu-quad",
+    "twu-quad-twu-feb-22": "twu-quad",
+    "twu-quad-kent-state-feb-22": "twu-quad",
+    "twu-quad-arizona-state-feb-22": "twu-quad",
+    "twu-quad-texas-woman-s-feb-22": "twu-quad",
+    "stanford-feb-27": "stanford-feb-27",
+    "utah-state-mar-6": "utah-state-mar-6",
+}
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data")
+MEETS_FILE = os.path.join(DATA_DIR, "meets.json")
+
+
+def fetch_recap(url):
+    """Fetch a recap article and extract the body text."""
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=15) as r:
+            html = r.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"  Failed to fetch {url}: {e}")
+        return None
+
+    # Strip scripts and styles
+    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL)
+    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL)
+
+    # Convert to plain text
+    text = re.sub(r"<[^>]+>", " ", html)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+
+    # Try to extract between CORVALLIS/city dateline and Related News
+    cities = ["CORVALLIS", "PROVO", "SEATTLE", "TUSCALOOSA", "BOISE", "DENTON", "LOGAN"]
+    idx = -1
+    for city in cities:
+        idx = text.find(city)
+        if idx >= 0:
+            break
+
+    if idx < 0:
+        # Fallback: look for the article body area
+        idx = text.find("Ore.")
+        if idx < 0:
+            idx = text.find("Utah")
+
+    end = len(text)
+    for marker in ["Related News", "Related Stories", "RELATED NEWS"]:
+        pos = text.find(marker, max(idx, 0))
+        if pos > 0:
+            end = min(end, pos)
+            break
+
+    if idx >= 0:
+        excerpt = text[idx:end].strip()
+        # Clean up: remove excessive whitespace, normalize paragraphs
+        lines = [l.strip() for l in excerpt.split("\n") if l.strip()]
+        return "\n\n".join(lines)
+
+    return None
+
+
+def main():
+    print("=== Fetching Meet Recaps ===\n")
+
+    # Fetch all unique recaps
+    recaps = {}
+    for key, url in RECAP_URLS.items():
+        print(f"Fetching {key}...")
+        text = fetch_recap(url)
+        if text:
+            recaps[key] = {"text": text, "url": url}
+            print(f"  OK ({len(text)} chars)")
+        else:
+            print(f"  FAILED")
+
+    # Load meets.json and add recaps
+    with open(MEETS_FILE, "r") as f:
+        meets = json.load(f)
+
+    updated = 0
+    for meet in meets:
+        recap_key = MEET_ID_TO_RECAP.get(meet["id"])
+        if recap_key and recap_key in recaps:
+            meet["recap"] = recaps[recap_key]["text"]
+            meet["recapUrl"] = recaps[recap_key]["url"]
+            updated += 1
+
+    with open(MEETS_FILE, "w") as f:
+        json.dump(meets, f, indent=2)
+
+    print(f"\nUpdated {updated}/{len(meets)} meets with recaps")
+    print(f"Wrote to {MEETS_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements both parts of issue #6:

### Part 1: Cross-linking Everything

- **Hash-based URL routing**: `#season`, `#meet/{id}`, `#gymnast/{slug}`, `#leaderboard/{event}`, `#opponent/{slug}` — all shareable
- **Browser back/forward** navigation works correctly via `popstate` listener
- **Breadcrumbs** on meet detail (`Season › Stanford Feb 27`) and gymnast profile (`Gymnasts › Sophia Esposito`)
- **Meet Detail → Leaderboard**: Event names and team event scores link to that event's leaderboard
- **Meet Detail → Gymnast Profile**: All athlete names are clickable links
- **Gymnast Profile → Meet Detail**: Every score in the history table links to that meet; PB badges link to the PB meet
- **Opponent name → Opponent Meets**: Clicking an opponent shows all meets vs that team
- **Leaderboard → Gymnast + Meet**: Gymnast names link to profile, meet context links to meet detail
- **Score trend chart** dots are clickable → navigate to that meet
- **Event bar labels** on season cards are clickable → navigate to that event's leaderboard

### Part 2: Meet Recaps

- New `scripts/fetch_recaps.py` scrapes recap articles from osubeavers.com for all 10 meets
- Recap text and source URL stored in `data/meets.json` per meet object
- All 16 meet records populated with recaps
- **Recap card** on meet detail page with readable typography, lede highlight, attribution link, and mobile-collapsible content

### Acceptance Criteria

- [x] Event name on meet detail → leaderboard
- [x] Gymnast name anywhere → profile
- [x] Score in history table → meet detail
- [x] Hash routing works with direct URLs
- [x] Browser back/forward navigation
- [x] Recap text in meets.json for all 10 meets
- [x] Recap displays with attribution
- [x] Recap collapsible on mobile
- [x] Breadcrumbs on meet detail and gymnast profile

Closes #6