### PR TITLE
feat: add PM2 process manager and /healthz endpoint

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [{
+    name: 'osu-gymnastics',
+    script: 'server.js',
+    cwd: '/home/mansona/workspace/osu-gymnatics-2026',
+    watch: false,
+    restart_delay: 2000,
+    max_restarts: 10,
+    env: { NODE_ENV: 'production', PORT: 8888 }
+  }]
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
+    "pm2:start": "pm2 start ecosystem.config.js",
+    "pm2:restart": "pm2 restart osu-gymnastics",
+    "pm2:stop": "pm2 stop osu-gymnastics",
+    "pm2:logs": "pm2 logs osu-gymnastics",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -3,11 +3,17 @@ const path = require('path');
 const app = express();
 
 app.use(express.static('public'));
+
 app.get('/api/meets', (req, res) => {
   res.sendFile(path.join(__dirname, 'data', 'meets.json'));
 });
 
-const PORT = 8888;
+app.get('/healthz', (req, res) => {
+  const { name, version } = require('./package.json');
+  res.json({ status: 'ok', uptime: process.uptime(), version });
+});
+
+const PORT = process.env.PORT || 8888;
 app.listen(PORT, () => {
   console.log(`🤸 OSU Gymnastics 2026 running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary

Addresses issue #13

- **PM2 installed** globally and `osu-gymnastics` process registered + saved
- **`ecosystem.config.js`** added to repo with auto-restart config (2s delay, max 10 restarts, PORT 8888)
- **PM2 scripts** added to `package.json`: `pm2:start`, `pm2:restart`, `pm2:stop`, `pm2:logs`
- **`GET /healthz`** endpoint returns `{ status: "ok", uptime, version }`
- Server now uses `process.env.PORT` with 8888 fallback (works with PM2 env config)

## After merging

Run the following to apply code changes to the live process:
```bash
pm2 restart osu-gymnastics
```

To enable auto-start on reboot (requires sudo):
```bash
pm2 startup  # copy and run the output command with sudo
pm2 save
```