### PR TITLE
fix: resolve Taylor DeVries name split bug creating phantom athletes

### DIFF
--- a/data/meets.json
+++ b/data/meets.json
@@ -1,378 +1,12 @@
 [
   {
-    "id": "best-of-west-washington-jan-3",
-    "date": "2026-01-03",
-    "opponent": "Washington",
-    "location": "Alaska Airlines Arena, Seattle, WA",
-    "isHome": false,
-    "result": "L",
-    "osuScore": 195.550,
-    "opponentScore": 195.625,
-    "quadMeet": true,
-    "quadName": "Best of the West Quad",
-    "events": {
-      "vault": {
-        "osu": 48.85,
-        "opponent": 48.675
-      },
-      "bars": {
-        "osu": 48.95,
-        "opponent": 48.725
-      },
-      "beam": {
-        "osu": 49.075,
-        "opponent": 49.275
-      },
-      "floor": {
-        "osu": 48.675,
-        "opponent": 48.95
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75
-        }
-      },
-      {
-        "name": "Katie Rude",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.375
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725,
-          "bars": 9.75,
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.675,
-          "beam": 9.7
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.825,
-          "floor": 9.8
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.7
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.4,
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.75,
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Taylor DeVries",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.925
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.8
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Sophia Kaloudis",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "UCLA",
-        "rank": 1,
-        "total": 196.975,
-        "vault": 49.15,
-        "bars": 49.225,
-        "beam": 49.525,
-        "floor": 49.075
-      },
-      {
-        "team": "California",
-        "rank": 2,
-        "total": 196.0,
-        "vault": 48.975,
-        "bars": 49.275,
-        "beam": 49.025,
-        "floor": 48.725
-      },
-      {
-        "team": "Washington",
-        "rank": 3,
-        "total": 195.625,
-        "vault": 48.675,
-        "bars": 48.725,
-        "beam": 49.275,
-        "floor": 48.95
-      },
-      {
-        "team": "Oregon State",
-        "rank": 4,
-        "total": 195.55,
-        "vault": 48.85,
-        "bars": 48.95,
-        "beam": 49.075,
-        "floor": 48.675
-      }
-    ]
-  },
-  {
-    "id": "best-of-west-california-jan-3",
-    "date": "2026-01-03",
-    "opponent": "California",
-    "location": "Alaska Airlines Arena, Seattle, WA",
-    "isHome": false,
-    "result": "L",
-    "osuScore": 195.550,
-    "opponentScore": 196.000,
-    "quadMeet": true,
-    "quadName": "Best of the West Quad",
-    "events": {
-      "vault": {
-        "osu": 48.85,
-        "opponent": 48.975
-      },
-      "bars": {
-        "osu": 48.95,
-        "opponent": 49.275
-      },
-      "beam": {
-        "osu": 49.075,
-        "opponent": 49.025
-      },
-      "floor": {
-        "osu": 48.675,
-        "opponent": 48.725
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75
-        }
-      },
-      {
-        "name": "Katie Rude",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.375
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725,
-          "bars": 9.75,
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.675,
-          "beam": 9.7
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.825,
-          "floor": 9.8
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.7
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.4,
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.75,
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Taylor DeVries",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.925
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.8
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Sophia Kaloudis",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "UCLA",
-        "rank": 1,
-        "total": 196.975,
-        "vault": 49.15,
-        "bars": 49.225,
-        "beam": 49.525,
-        "floor": 49.075
-      },
-      {
-        "team": "California",
-        "rank": 2,
-        "total": 196.0,
-        "vault": 48.975,
-        "bars": 49.275,
-        "beam": 49.025,
-        "floor": 48.725
-      },
-      {
-        "team": "Washington",
-        "rank": 3,
-        "total": 195.625,
-        "vault": 48.675,
-        "bars": 48.725,
-        "beam": 49.275,
-        "floor": 48.95
-      },
-      {
-        "team": "Oregon State",
-        "rank": 4,
-        "total": 195.55,
-        "vault": 48.85,
-        "bars": 48.95,
-        "beam": 49.075,
-        "floor": 48.675
-      }
-    ]
-  },
-  {
     "id": "best-of-west-ucla-jan-3",
     "date": "2026-01-03",
     "opponent": "UCLA",
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
+    "osuScore": 195.55,
     "opponentScore": 196.975,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
@@ -470,7 +104,376 @@
         "name": "Taylor DeVries",
         "team": "Oregon State",
         "scores": {
-          "bars": 9.925
+          "bars": 9.925,
+          "floor": 9.65
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.8
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Sophia Kaloudis",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "UCLA",
+        "rank": 1,
+        "total": 196.975,
+        "vault": 49.15,
+        "bars": 49.225,
+        "beam": 49.525,
+        "floor": 49.075
+      },
+      {
+        "team": "California",
+        "rank": 2,
+        "total": 196.0,
+        "vault": 48.975,
+        "bars": 49.275,
+        "beam": 49.025,
+        "floor": 48.725
+      },
+      {
+        "team": "Washington",
+        "rank": 3,
+        "total": 195.625,
+        "vault": 48.675,
+        "bars": 48.725,
+        "beam": 49.275,
+        "floor": 48.95
+      },
+      {
+        "team": "Oregon State",
+        "rank": 4,
+        "total": 195.55,
+        "vault": 48.85,
+        "bars": 48.95,
+        "beam": 49.075,
+        "floor": 48.675
+      }
+    ]
+  },
+  {
+    "id": "best-of-west-california-jan-3",
+    "date": "2026-01-03",
+    "opponent": "California",
+    "location": "Alaska Airlines Arena, Seattle, WA",
+    "isHome": false,
+    "result": "L",
+    "osuScore": 195.55,
+    "opponentScore": 196.0,
+    "quadMeet": true,
+    "quadName": "Best of the West Quad",
+    "events": {
+      "vault": {
+        "osu": 48.85,
+        "opponent": 48.975
+      },
+      "bars": {
+        "osu": 48.95,
+        "opponent": 49.275
+      },
+      "beam": {
+        "osu": 49.075,
+        "opponent": 49.025
+      },
+      "floor": {
+        "osu": 48.675,
+        "opponent": 48.725
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75
+        }
+      },
+      {
+        "name": "Katie Rude",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.375
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725,
+          "bars": 9.75,
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.675,
+          "beam": 9.7
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.825,
+          "floor": 9.8
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.7
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.4,
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.75,
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.925,
+          "floor": 9.65
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.8
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Sophia Kaloudis",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "UCLA",
+        "rank": 1,
+        "total": 196.975,
+        "vault": 49.15,
+        "bars": 49.225,
+        "beam": 49.525,
+        "floor": 49.075
+      },
+      {
+        "team": "California",
+        "rank": 2,
+        "total": 196.0,
+        "vault": 48.975,
+        "bars": 49.275,
+        "beam": 49.025,
+        "floor": 48.725
+      },
+      {
+        "team": "Washington",
+        "rank": 3,
+        "total": 195.625,
+        "vault": 48.675,
+        "bars": 48.725,
+        "beam": 49.275,
+        "floor": 48.95
+      },
+      {
+        "team": "Oregon State",
+        "rank": 4,
+        "total": 195.55,
+        "vault": 48.85,
+        "bars": 48.95,
+        "beam": 49.075,
+        "floor": 48.675
+      }
+    ]
+  },
+  {
+    "id": "best-of-west-washington-jan-3",
+    "date": "2026-01-03",
+    "opponent": "Washington",
+    "location": "Alaska Airlines Arena, Seattle, WA",
+    "isHome": false,
+    "result": "L",
+    "osuScore": 195.55,
+    "opponentScore": 195.625,
+    "quadMeet": true,
+    "quadName": "Best of the West Quad",
+    "events": {
+      "vault": {
+        "osu": 48.85,
+        "opponent": 48.675
+      },
+      "bars": {
+        "osu": 48.95,
+        "opponent": 48.725
+      },
+      "beam": {
+        "osu": 49.075,
+        "opponent": 49.275
+      },
+      "floor": {
+        "osu": 48.675,
+        "opponent": 48.95
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75
+        }
+      },
+      {
+        "name": "Katie Rude",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.375
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725,
+          "bars": 9.75,
+          "floor": 9.7
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.675,
+          "beam": 9.7
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.825,
+          "floor": 9.8
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.7
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.4,
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.75,
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.925,
+          "floor": 9.65
         }
       },
       {
@@ -834,7 +837,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "W",
-    "osuScore": 196.600,
+    "osuScore": 196.6,
     "opponentScore": 196.075,
     "events": {
       "vault": {
@@ -962,7 +965,7 @@
     "isHome": false,
     "result": "L",
     "osuScore": 195.825,
-    "opponentScore": 197.450,
+    "opponentScore": 197.45,
     "events": {
       "vault": {
         "osu": 49.175,
@@ -1091,188 +1094,17 @@
           "beam": 9.7
         }
       }
-    ]
-  },
-  {
-    "id": "boise-state-quad-boise-feb-6",
-    "date": "2026-02-06",
-    "opponent": "Boise State",
-    "location": "ExtraMile Arena, Boise, ID",
-    "isHome": false,
-    "result": "W",
-    "osuScore": 195.450,
-    "opponentScore": 195.350,
-    "quadMeet": true,
-    "quadName": "Boise State Quad",
-    "events": {
-      "vault": {
-        "osu": 49.025,
-        "opponent": 48.85
-      },
-      "bars": {
-        "osu": 49.1,
-        "opponent": 48.975
-      },
-      "beam": {
-        "osu": 48.45,
-        "opponent": 48.625
-      },
-      "floor": {
-        "osu": 48.875,
-        "opponent": 48.9
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "floor": 8.475
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.7,
-          "floor": 9.825
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.8,
-          "bars": 9.725
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.825,
-          "bars": 9.725,
-          "beam": 9.775,
-          "floor": 9.9
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "beam": 9.675
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.85,
-          "beam": 9.525
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.875,
-          "beam": 9.5
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.65
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.825
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.675
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      }
     ],
-    "attendance": "2,677",
-    "allTeams": [
-      {
-        "team": "San Jose State",
-        "rank": 1,
-        "total": 195.475,
-        "vault": 49.2,
-        "bars": 48.975,
-        "beam": 48.75,
-        "floor": 48.55
-      },
-      {
-        "team": "Oregon State",
-        "rank": 2,
-        "total": 195.45,
-        "vault": 49.025,
-        "bars": 49.1,
-        "beam": 48.45,
-        "floor": 48.875
-      },
-      {
-        "team": "Boise State",
-        "rank": 3,
-        "total": 195.35,
-        "vault": 48.85,
-        "bars": 48.975,
-        "beam": 48.625,
-        "floor": 48.9
-      },
-      {
-        "team": "UC Davis",
-        "rank": 4,
-        "total": 193.025,
-        "vault": 48.075,
-        "bars": 48.65,
-        "beam": 47.75,
-        "floor": 48.55
-      }
-    ]
+    "imageBasedPdf": true
   },
   {
-    "id": "boise-state-quad-sjsu-feb-6",
+    "id": "boise-state-quad-san-jose-state-feb-6",
     "date": "2026-02-06",
-    "opponent": "San José State",
+    "opponent": "San Jose State",
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 195.475,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1342,7 +1174,8 @@
         "team": "Oregon State",
         "scores": {
           "vault": 9.775,
-          "beam": 9.675
+          "beam": 9.675,
+          "floor": 9.775
         }
       },
       {
@@ -1390,14 +1223,13 @@
         }
       },
       {
-        "name": "Olivia Buckner",
+        "name": "Taylor DeVries",
         "team": "Oregon State",
         "scores": {
-          "floor": 9.775
+          "floor": 9.7
         }
       }
     ],
-    "attendance": "2,677",
     "allTeams": [
       {
         "team": "San Jose State",
@@ -1435,16 +1267,190 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "attendance": "2,677"
   },
   {
-    "id": "boise-state-quad-ucdavis-feb-6",
+    "id": "boise-state-quad-boise-state-feb-6",
+    "date": "2026-02-06",
+    "opponent": "Boise State",
+    "location": "ExtraMile Arena, Boise, ID",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.45,
+    "opponentScore": 195.35,
+    "quadMeet": true,
+    "quadName": "Boise State Quad",
+    "events": {
+      "vault": {
+        "osu": 49.025,
+        "opponent": 48.85
+      },
+      "bars": {
+        "osu": 49.1,
+        "opponent": 48.975
+      },
+      "beam": {
+        "osu": 48.45,
+        "opponent": 48.625
+      },
+      "floor": {
+        "osu": 48.875,
+        "opponent": 48.9
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "floor": 8.475
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.7,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.8,
+          "bars": 9.725
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.725,
+          "beam": 9.775,
+          "floor": 9.9
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "beam": 9.675,
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.825
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.85,
+          "beam": 9.525
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.875,
+          "beam": 9.5
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.65
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.675
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.7
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "San Jose State",
+        "rank": 1,
+        "total": 195.475,
+        "vault": 49.2,
+        "bars": 48.975,
+        "beam": 48.75,
+        "floor": 48.55
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.45,
+        "vault": 49.025,
+        "bars": 49.1,
+        "beam": 48.45,
+        "floor": 48.875
+      },
+      {
+        "team": "Boise State",
+        "rank": 3,
+        "total": 195.35,
+        "vault": 48.85,
+        "bars": 48.975,
+        "beam": 48.625,
+        "floor": 48.9
+      },
+      {
+        "team": "UC Davis",
+        "rank": 4,
+        "total": 193.025,
+        "vault": 48.075,
+        "bars": 48.65,
+        "beam": 47.75,
+        "floor": 48.55
+      }
+    ],
+    "attendance": "2,677"
+  },
+  {
+    "id": "boise-state-quad-uc-davis-feb-6",
     "date": "2026-02-06",
     "opponent": "UC Davis",
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "W",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 193.025,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1514,7 +1520,8 @@
         "team": "Oregon State",
         "scores": {
           "vault": 9.775,
-          "beam": 9.675
+          "beam": 9.675,
+          "floor": 9.775
         }
       },
       {
@@ -1562,14 +1569,13 @@
         }
       },
       {
-        "name": "Olivia Buckner",
+        "name": "Taylor DeVries",
         "team": "Oregon State",
         "scores": {
-          "floor": 9.775
+          "floor": 9.7
         }
       }
     ],
-    "attendance": "2,677",
     "allTeams": [
       {
         "team": "San Jose State",
@@ -1607,7 +1613,8 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "attendance": "2,677"
   },
   {
     "id": "southern-utah-feb-14",
@@ -1616,7 +1623,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 196.300,
+    "osuScore": 196.3,
     "opponentScore": 196.825,
     "events": {
       "vault": {
@@ -1744,7 +1751,351 @@
     "attendance": "3,954"
   },
   {
-    "id": "twu-quad-kent-feb-22",
+    "id": "twu-quad-twu-feb-22",
+    "date": "2026-02-22",
+    "opponent": "TWU",
+    "location": "Kitty Magee Arena, Denton, TX",
+    "isHome": false,
+    "result": "L",
+    "osuScore": 195.775,
+    "opponentScore": 195.975,
+    "quadMeet": true,
+    "quadName": "TWU Quad",
+    "events": {
+      "vault": {
+        "osu": 48.975,
+        "opponent": 48.925
+      },
+      "bars": {
+        "osu": 48.9,
+        "opponent": 48.95
+      },
+      "beam": {
+        "osu": 48.9,
+        "opponent": 49.025
+      },
+      "floor": {
+        "osu": 49.0,
+        "opponent": 49.075
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75,
+          "floor": 9.85
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.775,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.775,
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.85
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.825,
+          "beam": 9.7,
+          "floor": 9.875
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.55
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.0,
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.9,
+          "beam": 9.225
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.6
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.675
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "TWU",
+        "rank": 1,
+        "total": 195.975,
+        "vault": 48.925,
+        "bars": 48.95,
+        "beam": 49.025,
+        "floor": 49.075
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.775,
+        "vault": 48.975,
+        "bars": 48.9,
+        "beam": 48.9,
+        "floor": 49.0
+      },
+      {
+        "team": "Arizona State",
+        "rank": 3,
+        "total": 195.55,
+        "vault": 49.05,
+        "bars": 48.475,
+        "beam": 48.9,
+        "floor": 49.125
+      },
+      {
+        "team": "Kent State",
+        "rank": 4,
+        "total": 195.075,
+        "vault": 48.925,
+        "bars": 49.0,
+        "beam": 48.325,
+        "floor": 48.825
+      }
+    ]
+  },
+  {
+    "id": "twu-quad-arizona-state-feb-22",
+    "date": "2026-02-22",
+    "opponent": "Arizona State",
+    "location": "Kitty Magee Arena, Denton, TX",
+    "isHome": false,
+    "result": "W",
+    "osuScore": 195.775,
+    "opponentScore": 195.55,
+    "quadMeet": true,
+    "quadName": "TWU Quad",
+    "events": {
+      "vault": {
+        "osu": 48.975,
+        "opponent": 49.05
+      },
+      "bars": {
+        "osu": 48.9,
+        "opponent": 48.475
+      },
+      "beam": {
+        "osu": 48.9,
+        "opponent": 48.9
+      },
+      "floor": {
+        "osu": 49.0,
+        "opponent": 49.125
+      }
+    },
+    "athletes": [
+      {
+        "name": "Kyanna Crabb",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.725
+        }
+      },
+      {
+        "name": "Reina Marchal",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.75,
+          "floor": 9.85
+        }
+      },
+      {
+        "name": "Savannah Miller",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.775,
+          "floor": 9.825
+        }
+      },
+      {
+        "name": "Olivia Buckner",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.85,
+          "beam": 9.775,
+          "floor": 9.775
+        }
+      },
+      {
+        "name": "Camryn Richardson",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.775,
+          "bars": 9.85
+        }
+      },
+      {
+        "name": "Sophia Esposito",
+        "team": "Oregon State",
+        "scores": {
+          "vault": 9.825,
+          "bars": 9.825,
+          "beam": 9.7,
+          "floor": 9.875
+        }
+      },
+      {
+        "name": "Francesca Caso",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.55
+        }
+      },
+      {
+        "name": "Kaylee Cheek",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 8.0,
+          "beam": 9.825
+        }
+      },
+      {
+        "name": "Ellie Weaver",
+        "team": "Oregon State",
+        "scores": {
+          "bars": 9.9,
+          "beam": 9.225
+        }
+      },
+      {
+        "name": "Mia Heather",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.75
+        }
+      },
+      {
+        "name": "Lauren Letzsch",
+        "team": "Oregon State",
+        "scores": {
+          "beam": 9.85
+        }
+      },
+      {
+        "name": "Paulina Vargas",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.6
+        }
+      },
+      {
+        "name": "Taylor DeVries",
+        "team": "Oregon State",
+        "scores": {
+          "floor": 9.675
+        }
+      }
+    ],
+    "allTeams": [
+      {
+        "team": "TWU",
+        "rank": 1,
+        "total": 195.975,
+        "vault": 48.925,
+        "bars": 48.95,
+        "beam": 49.025,
+        "floor": 49.075
+      },
+      {
+        "team": "Oregon State",
+        "rank": 2,
+        "total": 195.775,
+        "vault": 48.975,
+        "bars": 48.9,
+        "beam": 48.9,
+        "floor": 49.0
+      },
+      {
+        "team": "Arizona State",
+        "rank": 3,
+        "total": 195.55,
+        "vault": 49.05,
+        "bars": 48.475,
+        "beam": 48.9,
+        "floor": 49.125
+      },
+      {
+        "team": "Kent State",
+        "rank": 4,
+        "total": 195.075,
+        "vault": 48.925,
+        "bars": 49.0,
+        "beam": 48.325,
+        "floor": 48.825
+      }
+    ]
+  },
+  {
+    "id": "twu-quad-kent-state-feb-22",
     "date": "2026-02-22",
     "opponent": "Kent State",
     "location": "Kitty Magee Arena, Denton, TX",
@@ -1802,7 +2153,8 @@
         "team": "Oregon State",
         "scores": {
           "vault": 9.85,
-          "beam": 9.775
+          "beam": 9.775,
+          "floor": 9.775
         }
       },
       {
@@ -1868,352 +2220,10 @@
         }
       },
       {
-        "name": "Olivia Buckner",
+        "name": "Taylor DeVries",
         "team": "Oregon State",
         "scores": {
-          "floor": 9.775
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "TWU",
-        "rank": 1,
-        "total": 195.975,
-        "vault": 48.925,
-        "bars": 48.95,
-        "beam": 49.025,
-        "floor": 49.075
-      },
-      {
-        "team": "Oregon State",
-        "rank": 2,
-        "total": 195.775,
-        "vault": 48.975,
-        "bars": 48.9,
-        "beam": 48.9,
-        "floor": 49.0
-      },
-      {
-        "team": "Arizona State",
-        "rank": 3,
-        "total": 195.55,
-        "vault": 49.05,
-        "bars": 48.475,
-        "beam": 48.9,
-        "floor": 49.125
-      },
-      {
-        "team": "Kent State",
-        "rank": 4,
-        "total": 195.075,
-        "vault": 48.925,
-        "bars": 49.0,
-        "beam": 48.325,
-        "floor": 48.825
-      }
-    ]
-  },
-  {
-    "id": "twu-quad-asu-feb-22",
-    "date": "2026-02-22",
-    "opponent": "Arizona State",
-    "location": "Kitty Magee Arena, Denton, TX",
-    "isHome": false,
-    "result": "W",
-    "osuScore": 195.775,
-    "opponentScore": 195.550,
-    "quadMeet": true,
-    "quadName": "TWU Quad",
-    "events": {
-      "vault": {
-        "osu": 48.975,
-        "opponent": 49.05
-      },
-      "bars": {
-        "osu": 48.9,
-        "opponent": 48.475
-      },
-      "beam": {
-        "osu": 48.9,
-        "opponent": 48.9
-      },
-      "floor": {
-        "osu": 49.0,
-        "opponent": 49.125
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75,
-          "floor": 9.85
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "bars": 9.775,
-          "floor": 9.825
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.775
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "bars": 9.85
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.825,
-          "bars": 9.825,
-          "beam": 9.7,
-          "floor": 9.875
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.55
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.0,
-          "beam": 9.825
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.9,
-          "beam": 9.225
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.6
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "TWU",
-        "rank": 1,
-        "total": 195.975,
-        "vault": 48.925,
-        "bars": 48.95,
-        "beam": 49.025,
-        "floor": 49.075
-      },
-      {
-        "team": "Oregon State",
-        "rank": 2,
-        "total": 195.775,
-        "vault": 48.975,
-        "bars": 48.9,
-        "beam": 48.9,
-        "floor": 49.0
-      },
-      {
-        "team": "Arizona State",
-        "rank": 3,
-        "total": 195.55,
-        "vault": 49.05,
-        "bars": 48.475,
-        "beam": 48.9,
-        "floor": 49.125
-      },
-      {
-        "team": "Kent State",
-        "rank": 4,
-        "total": 195.075,
-        "vault": 48.925,
-        "bars": 49.0,
-        "beam": 48.325,
-        "floor": 48.825
-      }
-    ]
-  },
-  {
-    "id": "twu-quad-twu-feb-22",
-    "date": "2026-02-22",
-    "opponent": "Texas Woman's",
-    "location": "Kitty Magee Arena, Denton, TX",
-    "isHome": false,
-    "result": "L",
-    "osuScore": 195.775,
-    "opponentScore": 195.975,
-    "quadMeet": true,
-    "quadName": "TWU Quad",
-    "events": {
-      "vault": {
-        "osu": 48.975,
-        "opponent": 48.925
-      },
-      "bars": {
-        "osu": 48.9,
-        "opponent": 48.95
-      },
-      "beam": {
-        "osu": 48.9,
-        "opponent": 49.025
-      },
-      "floor": {
-        "osu": 49.0,
-        "opponent": 49.075
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75,
-          "floor": 9.85
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "bars": 9.775,
-          "floor": 9.825
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.775
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.775,
-          "bars": 9.85
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.825,
-          "bars": 9.825,
-          "beam": 9.7,
-          "floor": 9.875
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.55
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.0,
-          "beam": 9.825
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.9,
-          "beam": 9.225
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.6
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
+          "floor": 9.675
         }
       }
     ],
@@ -2263,8 +2273,8 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 197.250,
-    "opponentScore": 198.150,
+    "osuScore": 197.25,
+    "opponentScore": 198.15,
     "events": {
       "vault": {
         "osu": 49.3,
@@ -2313,7 +2323,8 @@
         "team": "Oregon State",
         "scores": {
           "vault": 9.9,
-          "beam": 9.825
+          "beam": 9.825,
+          "floor": 9.875
         }
       },
       {
@@ -2321,6 +2332,7 @@
         "team": "Oregon State",
         "scores": {
           "vault": 9.95,
+          "bars": 9.9,
           "beam": 9.95,
           "floor": 9.9,
           "aa": 39.7
@@ -2384,13 +2396,6 @@
         "scores": {
           "floor": 9.85
         }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.875
-        }
       }
     ],
     "attendance": "3,617"
@@ -2402,8 +2407,8 @@
     "location": "Dee Glen Smith Spectrum, Logan, UT",
     "isHome": false,
     "result": "L",
-    "osuScore": 196.150,
-    "opponentScore": 196.950,
+    "osuScore": 196.15,
+    "opponentScore": 196.95,
     "events": {
       "vault": {
         "osu": 48.975,
@@ -2524,6 +2529,7 @@
           "beam": 9.8
         }
       }
-    ]
+    ],
+    "imageBasedPdf": true
   }
 ]

--- a/scripts/parse_pdfs.py
+++ b/scripts/parse_pdfs.py
@@ -38,6 +38,7 @@ MEETS = [
         "id": "alabama-jan-30", "date": "2026-01-30", "opponent": "Alabama",
         "location": "Coleman Coliseum, Tuscaloosa, AL", "isHome": False,
         "url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/oregonstate.sidearmsports.com/documents/2026/1/31/AlabamaFINAL.pdf?timestamp=20260131043916",
+        "imageBasedPdf": True,
         "hardcoded": {
             "osuScore": 195.825, "opponentScore": 197.450, "result": "L",
             "events": {
@@ -95,6 +96,7 @@ MEETS = [
         "id": "utah-state-mar-6", "date": "2026-03-06", "opponent": "Utah State",
         "location": "Dee Glen Smith Spectrum, Logan, UT", "isHome": False,
         "url": "https://s3.us-east-2.amazonaws.com/sidearm.nextgen.sites/oregonstate.sidearmsports.com/documents/2026/3/7/Utah_State_vs._Oregon_State_-_Blank_Scoresheet.pdf?timestamp=20260307041803",
+        "imageBasedPdf": True,
         "hardcoded": {
             "osuScore": 196.150, "opponentScore": 196.950, "result": "L",
             "events": {
@@ -173,6 +175,56 @@ def split_concatenated_names(text):
         else:
             names.append(buf.strip())
     return names
+
+
+def fix_split_names(names):
+    """
+    Post-process parsed athlete names to fix artifacts from PDF line-break splitting.
+
+    Root cause: pypdf concatenates names without separators, and split_concatenated_names
+    splits on lowercase→uppercase boundaries. "DeVries" splits at "e|V" → "Taylor De"
+    becomes a standalone 2-word name, and "Vries" gets prepended to the next athlete.
+
+    Fixes:
+      1. "Taylor De" + "VriesNextAthlete" → "Taylor DeVries", "Next Athlete"
+      2. Any name starting with "Vries" has the prefix stripped (defensive fallback)
+    """
+    result = []
+    i = 0
+    while i < len(names):
+        name = names[i]
+        # Fix "Taylor De" split: look ahead for "Vries..." in the next name
+        if name == "Taylor De" and i + 1 < len(names) and names[i + 1].startswith("Vries"):
+            next_name = names[i + 1]
+            rest = next_name[5:].strip()  # Strip "Vries" prefix to get remaining athlete name
+            result.append("Taylor DeVries")
+            if rest:
+                result.append(rest)
+            i += 2
+            continue
+        # Defensive: strip "Vries" prefix from any name that still has it
+        if name.startswith("Vries") and len(name) > 5:
+            stripped = name[5:].strip()
+            if stripped:
+                result.append(stripped)
+            i += 1
+            continue
+        result.append(name)
+        i += 1
+    return result
+
+
+def merge_duplicate_athletes(athletes_dict):
+    """
+    Merge duplicate athlete entries (same name) by combining their event scores.
+    Returns a dict with one entry per athlete name.
+    """
+    merged = {}
+    for name, data in athletes_dict.items():
+        if name not in merged:
+            merged[name] = {"name": name, "team": data["team"], "scores": {}}
+        merged[name]["scores"].update(data["scores"])
+    return merged
 
 
 def parse_osu_athletes(pages_text):
@@ -287,6 +339,8 @@ def parse_osu_athletes(pages_text):
                             break
                     break
     
+    # Merge any duplicate athlete entries (same name, different events parsed separately)
+    athletes = merge_duplicate_athletes(athletes)
     return list(athletes.values())
 
 
@@ -295,6 +349,7 @@ def _flush_event(athletes, event, scores, names_text):
     if not event or not scores or not names_text:
         return
     names = split_concatenated_names(names_text)
+    names = fix_split_names(names)  # Fix Taylor DeVries line-break split artifacts
     for j, name in enumerate(names):
         if j < len(scores):
             if name not in athletes:
@@ -305,13 +360,16 @@ def _flush_event(athletes, event, scores, names_text):
 def parse_meet_pdf(meet_info):
     if "hardcoded" in meet_info:
         hc = meet_info["hardcoded"]
-        return {
+        record = {
             "id": meet_info["id"], "date": meet_info["date"],
             "opponent": meet_info["opponent"], "location": meet_info["location"],
             "isHome": meet_info["isHome"], "result": hc["result"],
             "osuScore": hc["osuScore"], "opponentScore": hc["opponentScore"],
             "events": hc["events"], "athletes": hc["athletes"],
         }
+        if meet_info.get("imageBasedPdf"):
+            record["imageBasedPdf"] = True
+        return record
     
     pdf_path = os.path.join(DOWNLOAD_DIR, f"{meet_info['id']}.pdf")
     reader = PdfReader(pdf_path)
@@ -327,6 +385,12 @@ def parse_meet_pdf(meet_info):
             team_results_pages.append(text)
         if "NCAA Gymnastics Score Sheet" in text:
             score_sheet_pages.append(text)
+    
+    # Detect image-based PDFs (scanned — no extractable text)
+    total_text = "".join(all_text).strip()
+    if not total_text:
+        print(f"  WARNING: PDF appears to be image-based (no extractable text). Individual scores unavailable.")
+        return None
     
     team_scores = {}
     for pt in team_results_pages:


### PR DESCRIPTION
## Summary

Fixes the athlete name parsing bug where `Taylor DeVries` was being split across a line break during PDF text extraction.

## Root Cause

`pypdf` concatenates PDF text lines without separators. When `split_concatenated_names()` splits on lowercase→uppercase boundaries, `DeVries` splits at the `e|V` transition: `"Taylor De"` becomes a standalone 2-word name, and `"Vries"` gets prepended to the **next** athlete's name (e.g., `"VriesSophia Esposito"`, `"VriesReina Marchal"`).

## Changes

### `scripts/parse_pdfs.py`

- **`fix_split_names(names)`** — New post-processor: detects `"Taylor De"` + `"VriesXxx"` consecutive names and merges them into `"Taylor DeVries"` + `"Xxx"`; also strips any remaining `"Vries"` prefixes as a defensive fallback
- **`merge_duplicate_athletes(athletes_dict)`** — New helper: consolidates duplicate athlete entries by merging event scores
- **`_flush_event()`** — Now calls `fix_split_names()` after `split_concatenated_names()`
- **`parse_osu_athletes()`** — Now calls `merge_duplicate_athletes()` at the end
- **`parse_meet_pdf()`** — Propagates `imageBasedPdf` flag to output records; detects image-only PDFs by checking for zero extracted text
- **Alabama** and **Utah State Mar** MEETS entries — Added `"imageBasedPdf": True` flag

### `data/meets.json`

Regenerated with all fixes applied.

## Validation

All checks pass:
- ✅ No athletes starting with `"Vries"` in any meet
- ✅ No athlete named `"Taylor De"` in any meet
- ✅ Stanford: `Taylor DeVries` has bars=9.825, floor=9.775
- ✅ Stanford: `Sophia Esposito` has vault, bars=9.900, beam, floor, aa all correct
- ✅ Stanford: `Olivia Buckner` has vault+beam+floor in a single entry (no duplicates)
- ✅ Alabama and Utah State Mar have `imageBasedPdf: true` in output JSON
- ✅ Server restarted and returning correct data on live API

Addresses issue #4