### PR TITLE
feat: cross-link all meet elements + embed meet recaps

### DIFF
--- a/data/meets.json
+++ b/data/meets.json
@@ -6,7 +6,7 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
+    "osuScore": 195.55,
     "opponentScore": 195.625,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
@@ -180,7 +180,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad",
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\r\n \n\r\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\r\n \n\r\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\r\n \n\r\nCamryn Richardson, competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\r\n \n\r\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\r\n \n\r\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT."
   },
   {
     "id": "best-of-west-california-jan-3",
@@ -189,8 +191,8 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
-    "opponentScore": 196.000,
+    "osuScore": 195.55,
+    "opponentScore": 196.0,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
     "events": {
@@ -363,7 +365,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad",
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\r\n \n\r\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\r\n \n\r\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\r\n \n\r\nCamryn Richardson, competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\r\n \n\r\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\r\n \n\r\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT."
   },
   {
     "id": "best-of-west-ucla-jan-3",
@@ -372,7 +376,7 @@
     "location": "Alaska Airlines Arena, Seattle, WA",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.550,
+    "osuScore": 195.55,
     "opponentScore": 196.975,
     "quadMeet": true,
     "quadName": "Best of the West Quad",
@@ -546,7 +550,9 @@
         "beam": 49.075,
         "floor": 48.675
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad",
+    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\r\n \n\r\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\r\n \n\r\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\r\n \n\r\nCamryn Richardson, competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\r\n \n\r\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\r\n \n\r\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT."
   },
   {
     "id": "byu-jan-9",
@@ -691,7 +697,9 @@
         }
       }
     ],
-    "attendance": "4,002"
+    "attendance": "4,002",
+    "recapUrl": "https://osubeavers.com/news/2026/1/9/womens-gymnastics-strong-foor-rotation-not-enough-in-loss-at-byu",
+    "recap": "PROVO, Utah \u2013 Oregon State gymnastics tallied the highest rotation score of either team in its dual against BYU, a 49.200 on floor exercise, but that wasn't enough as the Beavers finished with a 194.525 and fell to the Cougars on Friday inside the Marriott Center.\n\r\n \n\r\nEllie Weaver had a great meet for the Beavers in Provo, earning a 9.800 on bars in the team's first rotation before posting a 9.850 in the anchor spot on beam, which OSU competed in the fourth and final rotation. For the Vancouver, Wash., native, her performance was a near tenth of a point average improvement from last week, having posted a pair of 9.750s in Seattle.\n\r\n \n\r\nSophia Esposito won her first event title of the season on Friday, earning a 9.900 on floor to tie for the meet's highest score, also adding a 9.800 for her vault. Esposito, who earned a trio of 9.800-plus scores last weekend, also competed on beam along with Lauren Letzsch, who earned her second 9.800-plus score in as many weeks.\n\r\n \n\r\nUtah natives Olivia Buckner and Kaylee Cheek both competed close to home, with Buckner earning a 9.800 for her vault and Cheek hitting on both routines; Camryn Richardson added a 9.800 for her bars routine and was also given a 9.750 in her first floor exercise appearance of the season.\n\r\n \n\r\nThe Beaver floor lineup earned the highest rotation score of either team in Friday's competition, combining for a 49.200. Paulina Vargas scored a 9.825 that was followed by Richardson's 9.750, setting the stage for the back half of the lineup, which featured a Savannah Miller 9.875, Reina Marchal 9.850 and Esposito's 9.900.\n\r\n \n\r\nOregon State gymnastics returns home for its next two meets, hosting Sacramento State (Jan. 16, 7 p.m.) and Utah State (Jan. 25, 1 p.m.). Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
   },
   {
     "id": "sac-state-jan-16",
@@ -825,7 +833,9 @@
         }
       }
     ],
-    "attendance": "3,310"
+    "attendance": "3,310",
+    "recapUrl": "https://osubeavers.com/news/2026/1/16/womens-gymnastics-espositos-39-500-helps-beavers-to-home-victory",
+    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito put up a pair of 9.900-plus scores on her way to a 39.500 in the all-around, helping the Oregon State Beavers defeat Sacramento State 196.375-193.675 at Gill Coliseum.\n\r\n \n\r\nEsposito started the meet with a 9.850 during the Beavers' vault rotation and followed it up with a new career high on bars, 9.900, before a 9.825 on beam set the stage for another 9.900-plus, earning a 9.925 for her floor exercise routine. Friday's floor score marked Esposito's second-consecutive week finishing with the meet's highest score on that event.\n\r\n \n\r\nKyanna Crabb led the entire meet off with a 9.875 in the first spot of OSU's vault lineup, earning a 9.900 from judge two and setting a new Oregon State career high in the process. Originally from Vancouver, Wash., Crabb has vaulted and completed an exhibition routine on floor in every single meet this season, and earned a 9.925 for her exhibition on Friday.\n\r\n \n\r\nEllie Weaver set a new career high in the meet's second rotation, earning a 9.950 on the uneven bars while anchoring the lineup, surpassing the 9.925 she set against Utah on March 11, 2023; the Battle Ground, Wash., native also competed on the beam, earning a 9.775, moving her beam average to 9.792 on the season while improving to a 9.833 average on the uneven bars.\n\r\n \n\r\nOlivia Buckner earned a pair of 9.875s on beam and floor, with the floor score setting a new personal best. Lauren Letzsch went 9.875 on beam while Savannah Miller earned a 9.875 on her floor routine for the second time in as many weeks.\n\r\n \n\r\nOSU's floor exercise lineup exceled against the Hornets, led off by Sophia Kaloudis' career-best 9.850 that was followed by a Paulina Vargas 9.825 and the 9.875s by Buckner and Miller; Esposito rounded out the rotation with her 9.925 to help the Beavers to a 49.350 rotation score, which is the highest on the season.\n\r\n \n\r\nThe Beavers improved in every single rotation, starting with a. 48.850 and progressing to a 49.050 bars score and 49.125 beam before floor exercise in the fourth.\n\r\n \n\r\nOregon State gymnastics stays home for its next meet, hosting Utah State next Sunday, Jan. 25. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
   },
   {
     "id": "utah-state-jan-25",
@@ -834,7 +844,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "W",
-    "osuScore": 196.600,
+    "osuScore": 196.6,
     "opponentScore": 196.075,
     "events": {
       "vault": {
@@ -952,7 +962,9 @@
         }
       }
     ],
-    "attendance": "3,651"
+    "attendance": "3,651",
+    "recapUrl": "https://osubeavers.com/news/2026/1/25/womens-gymnastics-beaver-bars-set-the-tone-in-victory-over-23rd-ranked-utah-state",
+    "recap": "CORVALLIS, Ore. \u2013 Oregon State Gymnastics defeated the No. 23 Utah State Aggies on Sunday inside Gill Coliseum, posting a season-high 196.600 to secure a second-consecutive home victory.\n\r\n\n\r\nOSU's bars lineup was pivotal in the win, posting a season-high score for a single rotation with five scores tallying a 49.425, counting no lower than a 9.800 and posting a trio of 9.900-plus scores.\n\r\n \n\r\nFrancesca Caso, competing in the two spot, tied her career high with a 9.900 before Camryn Richardson and Ellie Weaver ended the rotation with back-to-back 9.925s; Sophia Esposito scored a 9.800 and Kaylee Cheek set a new season and career high thanks to a 9.875.\n\r\n \n\r\nFor Richardson, the 9.925 was a new career high and earned her first career event title thanks to Sunday's tie with Weaver, while Weaver has now won back-to-back event titles on the uneven bars after a 9.950 against Sacramento State last week. Esposito's bars routine helped fuel a second all-around title in as many weeks, also earning scores of 9.825 (VT), 9.850 (BB) and 9.750 (FX) to finish with a 39.225.\n\r\n\n\r\nOlivia Buckner also won her second event title of the year thanks to a 9.850 vault score, later adding a 9.800 during the team's third rotation on beam. Sunday's vault marked a new season high for the Riverton, Utah, native, who had earned a 9.800 at BYU two weeks ago.\n\r\n \n\r\nMia Heather's 9.900 on the balance beam was the meet's highest score on that event, earning a raucous response from Beaver faithful in attendance while surpassing the 9.825 scored last season in Tuscaloosa, Ala., at the NCAA Regional. The beam score also continued a strong start to Heather's collegiate career, having now hit on each of the seven routines she's completed as a Beav.\n\r\n \n\r\nPaulina Vargas led off the final rotation with a career-best 9.875 on floor while Reina Marchal earned her second 9.800-plus score in four routines this season, scoring a 9.825, while Savannah Miller tied her career high on that event thanks a 9.900 - her ninth time posting a 9.900.\n\r\n \n\r\nOregon State gymnastics is on the road for its next two meets, heading to face the Alabama Crimson Tide in Tuscaloosa next week and then to Boise, Idaho, on Feb. 6 before returning home Feb. 14 for another Pac-12 preview against Southern Utah, which is scheduled for Feb. 14 at 2 p.m. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventatAlabamaL, 195.825-197.450Jan 30 (Fri)\n\n 4:30 p.m.RecapResultsSECN+PreviewLive Scoring History Full Schedule<h3 name=\"h3\" class=\"s-heading__m"
   },
   {
     "id": "alabama-jan-30",
@@ -962,7 +974,7 @@
     "isHome": false,
     "result": "L",
     "osuScore": 195.825,
-    "opponentScore": 197.450,
+    "opponentScore": 197.45,
     "events": {
       "vault": {
         "osu": 49.175,
@@ -1091,7 +1103,9 @@
           "beam": 9.7
         }
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/1/30/womens-gymnastics-beaver-gymnastics-falls-to-no-3-alabama",
+    "recap": "TUSCALOOSA, Ala. \u2013 Oregon State gymnastics was in action Friday night, posting a 195.825 in a road loss to No. 3 Alabama.\n\r\n\n\r\nThe Beaver beam lineup had a strong meet against the Tide, posting OSU's highest rotation score of any event, 49.100. Led off by Sophia Esposito's second-consecutive 9.850, Olivia Buckner earned a 9.825 to setup Kaylee Cheek, who tied a season and career high with a 9.850. Mia Heather and Lauren Letzch were both given 9.750s before Ellie Weaver anchored the lineup with a 9.825.\n\r\n \n\r\nCheek's performance came on the heels of a 9.850 on bars in rotation one, making it two-straight weeks with a 9.850 or better on that event after posting a 9.875 against No. 23 Utah State last week inside Gill Coliseum. Cheek, a freshman from Spanish Fork, Utah, has competed on bars and beam in every single meet this season.\n\r\n \n\r\nEsposito's strong bars score contributed to a 39.325 in the all-around, earning a pair of 9.800s on vault and bars before finishing her meet with a team-leading 9.875 on floor and the 9.850 beam score. The team-leader in total routines (18) and hits (18), Esposito has now posted a 9.800 or better in all but two of her routines this season.\n\r\n \n\r\nOlivia Buckner earned a pair of 9.825s on vault and beam, her second time earning a pair of 9.800-plus scores in as many weeks, while Savannah Miller posted a 9.850 during the team's floor rotation to make it four-consecutive weeks with a 9.850 or better on that event; Miller previously tied her career high with a 9.900 during last week's meet.\n\r\n \n\r\nAlabama posted a 197.450 to win Friday's competition.\n\r\n\n\r\nOregon State gymnastics stays on the road for its next meet, heading to Boise, Idaho, for a quad meet hosted by the Broncos that also features San Jos\u00e9 State and UC Davis. Action at ExtraMile Arena is slated to begin at 6 p.m. PT / 7 p.m. MT.\n\r\n \n\r\nThe team returns home Feb. 14 for a Pac-12 preview against Southern Utah, which is scheduled for Feb. 14 at 2 p.m. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventSan Jos\u00e9 StateL, 195.450-195.475Feb 6 (Fri)\n\n 6 p.m.RecapResultsWatchPreviewLive Scoring History Full Schedule Players Mentioned<a href=\"/sports/womens-gymnastics/roster/oli"
   },
   {
     "id": "boise-state-quad-boise-feb-6",
@@ -1100,8 +1114,8 @@
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "W",
-    "osuScore": 195.450,
-    "opponentScore": 195.350,
+    "osuScore": 195.45,
+    "opponentScore": 195.35,
     "quadMeet": true,
     "quadName": "Boise State Quad",
     "events": {
@@ -1263,16 +1277,18 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet",
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos\u00e9 State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\r\n\n\r\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos\u00e9 State, who used a huge vault score in the final rotation to take the meet.\n\r\n\n\r\nEllie Weaver's 9.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from Camryn Richardson and included both a 9.8500 from Kaylee Cheek and 9.825 from Francesca Caso. For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\r\n\n\r\nLauren Letzsch won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\r\n\n\r\nSophia Esposito competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\r\n\n\r\nReina Marchal earned a 9.825 for her floor routine while Savannah Miller put up a career-high 9.800 while vaulting during the third rotation; Camryn Richardson had another solid meet on vault (9.775) and bars (9.825).\n\r\n\n\r\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n\n\r\n \n\n\r\nSkip Ad Next EventvsSouthern UtahL, 196.300-196.825Feb 14 (Sat)\n\n 2 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<"
   },
   {
     "id": "boise-state-quad-sjsu-feb-6",
     "date": "2026-02-06",
-    "opponent": "San José State",
+    "opponent": "San Jos\u00e9 State",
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "L",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 195.475,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1435,7 +1451,9 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet",
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos\u00e9 State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\r\n\n\r\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos\u00e9 State, who used a huge vault score in the final rotation to take the meet.\n\r\n\n\r\nEllie Weaver's 9.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from Camryn Richardson and included both a 9.8500 from Kaylee Cheek and 9.825 from Francesca Caso. For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\r\n\n\r\nLauren Letzsch won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\r\n\n\r\nSophia Esposito competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\r\n\n\r\nReina Marchal earned a 9.825 for her floor routine while Savannah Miller put up a career-high 9.800 while vaulting during the third rotation; Camryn Richardson had another solid meet on vault (9.775) and bars (9.825).\n\r\n\n\r\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n\n\r\n \n\n\r\nSkip Ad Next EventvsSouthern UtahL, 196.300-196.825Feb 14 (Sat)\n\n 2 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<"
   },
   {
     "id": "boise-state-quad-ucdavis-feb-6",
@@ -1444,7 +1462,7 @@
     "location": "ExtraMile Arena, Boise, ID",
     "isHome": false,
     "result": "W",
-    "osuScore": 195.450,
+    "osuScore": 195.45,
     "opponentScore": 193.025,
     "quadMeet": true,
     "quadName": "Boise State Quad",
@@ -1607,7 +1625,9 @@
         "beam": 47.75,
         "floor": 48.55
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/6/womens-gymnastics-comeback-falls-short-at-boise-state-quad-meet",
+    "recap": "BOISE, Idaho \u2013 Oregon State gymnastics placed second in a quad meet on Friday, tallying a 195.450 to finish behind San Jos\u00e9 State (195.475) but ahead of hosts Boise State (195.350) and UC Davis (193.025).\n\r\n\n\r\nAfter starting slow with a 48.450 during the opening rotation on beam, the Beavers built momentum throughout the meet, increasing each rotation score \u2013 which included a season-best 49.025 on vault \u2013 to rally and finish just behind San Jos\u00e9 State, who used a huge vault score in the final rotation to take the meet.\n\r\n\n\r\nEllie Weaver's 9.875 paced the bar lineup's 49.100, which came on the heels of a 9.825 from Camryn Richardson and included both a 9.8500 from Kaylee Cheek and 9.825 from Francesca Caso. For Weaver, the bars score was her third 9.850 or better this season and tied for the highest score in the meet, which makes it three event titles on the season for the Battle Ground, Wash., native.\n\r\n\n\r\nLauren Letzsch won her second event title of the 2026 season with a beautiful beam routine that was given a 9.825, one of just three 9.800 or better scores given out of 24 athletes to compete in the competition. A beam specialist who led the team in average score (9.810) entering Friday's meet, Letzsch has now earned a 9.800 or better in four competitions this season.\n\r\n\n\r\nSophia Esposito competed as an all-arounder for the fourth-consecutive week and won a pair of event titles on floor exercise and in the all-around, finishing with scores of 9.825 (VT), 9.725 (UB), 9.775 (BB) and 9.900 (FX) to finish with a 39.225. With two more event titles, Esposito increased her season total to six, which leads the team.\n\r\n\n\r\nReina Marchal earned a 9.825 for her floor routine while Savannah Miller put up a career-high 9.800 while vaulting during the third rotation; Camryn Richardson had another solid meet on vault (9.775) and bars (9.825).\n\r\n\n\r\nOregon State returns home for a meet Feb. 14, hosting a Pac-12 preview against Southern Utah, which is scheduled for 2 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n\n\r\n \n\n\r\nSkip Ad Next EventvsSouthern UtahL, 196.300-196.825Feb 14 (Sat)\n\n 2 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<"
   },
   {
     "id": "southern-utah-feb-14",
@@ -1616,7 +1636,7 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 196.300,
+    "osuScore": 196.3,
     "opponentScore": 196.825,
     "events": {
       "vault": {
@@ -1741,7 +1761,9 @@
         }
       }
     ],
-    "attendance": "3,954"
+    "attendance": "3,954",
+    "recapUrl": "https://osubeavers.com/news/2026/2/14/womens-gymnastics-season-highs-on-beam-and-floor-not-enough-in-loss-to-suu",
+    "recap": "CORVALLIS, Ore. \u2013 Despite posting season-best marks on beam (49.350) and floor (49.400), Oregon State Gymnastics fell to the Southern Utah Flippin' Birds on Saturday, finishing with a 196.300 against a future Pac-12 opponent inside legendary Gill Coliseum.\n\r\n \n\r\nOlivia Buckner had a fantastic meet against SUU, finishing with scores of 9.875 (VT), 9.825 (BB) and 9.875 (FX). The vault score set a new season high and her 9.875 on floor tied a season and career high mark; Saturday's performance was also her first time with three or more 9.800-plus scores since the NCAA Tuscaloosa Regional Semifinal last spring.\n\r\n \n\r\nSophia Esposito's incredible performances in the all-around continued Saturday, finishing with a 39.450 that included bars and floor scores which tied a career high. The Melville, N.Y., native started her meet by vaulting to a 9.775 before earning her first 9.900 on the uneven bars, using that momentum to post a 9.825 for the beam team and rounding out the meet with another 9.900-plus, this time a 9.950 on floor.\n\r\n \n\r\nEsposito, who's now competed all-around in five-straight competitions, won event titles on bars and floor, and has now posted a 9.900 or better in consecutive weeks after earning a 9.900 for her floor routine in Boise.\n\r\n \n\r\nLauren Letzsch was also in the 9.900s on Saturday, earning a season high 9.925 for OSU's beam lineup that came within striking distance of her career high, which is 9.950. Letzsch, who entered the meet as the team-leader in average beam score, has now won three event titles this season that event.\n\r\n \n\r\nKaylee Cheek was also part of the 9.900 club, also earning her 9.900 on the balance beam. A true freshman from Spanish Fork, Utah, Cheek has competed on beam and bars in every meet this season and has earned a 9.850 or better for her beam routine on three different occasions.\n\r\n \n\r\nThat third rotation saw OSU score a season-high 49.350 on the beam, starting with a pair of 9.825s by Mia Heather and Buckner. After Cheek's 9.900, Ellie Weaver stepped up with a 9.875 to set the stage for Letzsch's 9.925 and an Esposito 9.825. Entering the meet as the 21st-ranked beam lineup in the country, the rotation score bested the lineup's 49.125 score against Sacramento State on Jan. 16.\n\r\n \n\r\nOSU's floor group stole the show, however, putting up a 49.400 that counted no lower than a 9.825. Sophia Kaloudis was back in the lineup and earned that 9.825 before Buckner's 9.875 and a Reina Marchal 9.900 that set a new season and career high. Savannah Miller posted her fifth-consecutive 9.850 or better with an even 9.850 before Esposito's 9.950.\n\r\n \n\r\nSouthern Utah took the win with a 196.825.\n\r\n \n\r\nBeaver Gymnastics is on the road for its next meet, traveling to Denton, Texas, to compete against Texas Woman's and Kent State and Kent State in the TWU Tri Meet, returning home the following week to host Stanford Feb. 27. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventatTexas Woman'sL, 195.775-195.975Feb 22 (Sun)\n\n 12 p.m.RecapResultsWatchPreviewLive stats History Full Schedule"
   },
   {
     "id": "twu-quad-kent-feb-22",
@@ -1912,7 +1934,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet",
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\r\n \n\r\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\r\n \n\r\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\r\n \n\r\nAfter an early fall, OSU's bars lineup responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson, who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\r\n \n\r\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\r\n \n\r\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\r\n \n\r\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventvsStanfordL, 197.250-198.150Feb 27 (Fri)\n\n 7 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<div data-test-id"
   },
   {
     "id": "twu-quad-asu-feb-22",
@@ -1922,7 +1946,7 @@
     "isHome": false,
     "result": "W",
     "osuScore": 195.775,
-    "opponentScore": 195.550,
+    "opponentScore": 195.55,
     "quadMeet": true,
     "quadName": "TWU Quad",
     "events": {
@@ -2083,7 +2107,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet",
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\r\n \n\r\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\r\n \n\r\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\r\n \n\r\nAfter an early fall, OSU's bars lineup responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson, who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\r\n \n\r\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\r\n \n\r\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\r\n \n\r\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventvsStanfordL, 197.250-198.150Feb 27 (Fri)\n\n 7 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<div data-test-id"
   },
   {
     "id": "twu-quad-twu-feb-22",
@@ -2254,7 +2280,9 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet",
+    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\r\n \n\r\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\r\n \n\r\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\r\n \n\r\nAfter an early fall, OSU's bars lineup responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson, who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\r\n \n\r\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\r\n \n\r\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\r\n \n\r\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventvsStanfordL, 197.250-198.150Feb 27 (Fri)\n\n 7 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<div data-test-id"
   },
   {
     "id": "stanford-feb-27",
@@ -2263,8 +2291,8 @@
     "location": "Gill Coliseum, Corvallis, OR",
     "isHome": true,
     "result": "L",
-    "osuScore": 197.250,
-    "opponentScore": 198.150,
+    "osuScore": 197.25,
+    "opponentScore": 198.15,
     "events": {
       "vault": {
         "osu": 49.3,
@@ -2393,7 +2421,9 @@
         }
       }
     ],
-    "attendance": "3,617"
+    "attendance": "3,617",
+    "recapUrl": "https://osubeavers.com/news/2026/2/27/womens-gymnastics-espositos-career-night-leads-season-high-score",
+    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito earned four 9.900 or better scores on her way to a career-high 39.700 in the all-around as Oregon State Gymnastics' season-best 197.250 wasn't enough, falling to No. 10 Stanford's 198.150 inside legendary Gill Coliseum.\n\r\n \n\r\nEsposito bested her previous career high of 39.525 thanks to a pair of career highs on vault (9.950) and beam (9.950) to go with 9.9.00s on bars and floor. The Melville, N.Y., native has been tremendous as a junior in 2026, hitting on each of her 34 routines this season and has now posted a 9.900 or better on at least one event in three of her last four meets.\n\r\n \n\r\nOlivia Buckner had another fantastic performance, vaulting her way to a 9.900 before adding a 9.825 on the beam and 9.875 for her floor routine. With her vault, Buckner has now tallied a 9.850 or better on that event in each of the last three competitions, while the floor score tied a career high.\n\r\n \n\r\nBuckner and Esposito were both part of a strong showing for the vault lineup, who set a season-high rotation score with a 49.300. Led off by Reina Marchal's 9.775, Savannah Miller was given a 9.800 before Buckner and Esposito went back-to-back with their 9.900 and 9.950; Katie Rude finished the Beavers' scoring with a 9.875 that set a new career high.\n\r\n \n\r\nEllie Weaver led the way during OSU's bars rotation with a 9.925, her second-straight week with a 9.900 or better on that event, while the rotation also featured Esposito's 9.900, a Taylor DeVries 9.825 and Francesca Caso 9.800. \n\r\n \n\r\nThe Beaver beam lineup also set a new season-best rotation score, counting a pair of 9.900 or better scores and no lower than a 9.800. Led off by a Mia Heather 9.875 that was followed immediately by Buckner's 9.825 and a Kaylee Cheek 9.800, Lauren Letzsch posted her second 9.925 in the last three meets before Esposito's 9.950 to round out the team's 49.375 combined score on beam.\n\r\n \n\r\nSophia Kaloudis was back in the floor lineup and led it off with a career high-tying 9.850 before Buckner, Marchal and Miller rattled off three-straight 9.875s and Esposito's 9.900.\n\r\n \n\r\nFor Marchal, the 9.875 comes on the heels of a 9.850 last week in Texas and 9.900 the weekend before, while Miller's makes it six 9.850 or better scores in her last seven appearances.\n\r\n \n\r\nOregon State gymnastics is back on the road next weekend, heading to Logan, Utah, to face Utah State, returning home to face Denver on March 14 inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
   },
   {
     "id": "utah-state-mar-6",
@@ -2402,8 +2432,8 @@
     "location": "Dee Glen Smith Spectrum, Logan, UT",
     "isHome": false,
     "result": "L",
-    "osuScore": 196.150,
-    "opponentScore": 196.950,
+    "osuScore": 196.15,
+    "opponentScore": 196.95,
     "events": {
       "vault": {
         "osu": 48.975,
@@ -2524,6 +2554,8 @@
           "beam": 9.8
         }
       }
-    ]
+    ],
+    "recapUrl": "https://osubeavers.com/news/2026/3/6/womens-gymnastics-beaver-gymnastics-falls-to-utah-state",
+    "recap": "LOGAN, Utah \u2013 Oregon State gymnastics fell to future Pac-12 opponent Utah State Friday night, posting a 196.150 at the Dee Glen Smith Spectrum.\n\r\n \n\r\nThe Beaver floor lineup led the team's scoring with a 49.275 in the third rotation. Sophia Kaloudis and Reina Marchal led off with a pair of 9.800s that were followed by a pair of 9.850s from Olivia Buckner and Reina Marchal, which was immediately followed by Savannah Miller, who earned a 9.875, and Sophia Esposito, who was given the Beavers' only 9.900 of the meet.\n\r\n \n\r\nDeVries set a new career-high with her 9.800 and Buckner made it three meets in four weeks with a 9.850 or better on that event. Marchal's 9.850 was her fourth-consecutive 9.850 or better and Esposito has now earned a 9.900 in back-to-back weeks.\n\r\n \n\r\nSavannah Miller set a new career high on bars, leading off the lineup with a 9.850, setting the stage for a rotation that counted no lower than a 9.800. Following Miller's routine, Kaloudis earned a 9.800 before Francesca Caso and Esposito rattled off back-to-back 9.850s; Ellie Weaver finished the scoring with a 9.800.\n\r\n \n\r\nBuckner added a 9.875 on vault and 9.775 on beam, while Esposito vaulted her way to a 9.850 to cap a 39.275 in the all-around.\n\r\n \n\r\nUtah State finished the meet with a 196.650 to claim victory.\n\r\n \n\r\nOregon State gymnastics returns home to face Denver on March 14 inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
   }
 ]

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1098,3 +1098,206 @@ main {
     grid-template-columns: 1fr;
   }
 }
+
+/* ===== Breadcrumbs ===== */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+
+.breadcrumb-link {
+  color: var(--orange);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.breadcrumb-link:hover {
+  color: var(--orange-light);
+  text-decoration: underline;
+}
+
+.breadcrumb-sep {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.breadcrumb-current {
+  color: var(--text);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 260px;
+}
+
+/* ===== Inline Links (meet detail cross-links) ===== */
+.inline-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.inline-link:hover {
+  color: var(--orange-light);
+  border-bottom-color: var(--orange-light);
+}
+
+.detail-event-title .inline-link {
+  color: var(--text);
+  font-family: 'Oswald', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.detail-event-title .inline-link:hover {
+  color: var(--orange);
+}
+
+/* Gymnast name links in meet detail lineup */
+.lineup-table a.inline-link {
+  color: var(--text);
+}
+
+.lineup-table a.inline-link:hover {
+  color: var(--orange-light);
+}
+
+/* Leaderboard links */
+.lb-name a.inline-link {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.lb-context a.inline-link {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.lb-context a.inline-link:hover {
+  color: var(--orange-light);
+}
+
+/* Meet history table links */
+.meet-history-table a.inline-link {
+  color: var(--text);
+}
+
+.meet-history-table a.inline-link:hover {
+  color: var(--orange-light);
+}
+
+/* PB badge in history table */
+.pb-badge {
+  display: inline-block;
+  background: rgba(215, 63, 9, 0.25);
+  color: var(--orange);
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0 4px;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.pb-badge:hover {
+  background: rgba(215, 63, 9, 0.45);
+}
+
+/* Profile stat PB link */
+.profile-stat a.inline-link {
+  color: var(--text);
+}
+
+.profile-stat a.inline-link:hover {
+  color: var(--orange-light);
+}
+
+/* ===== Meet Recap Section ===== */
+.recap-card {
+  margin-bottom: 1.5rem;
+}
+
+.recap-body {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: #ddd;
+  max-width: 720px;
+}
+
+.recap-body p {
+  margin-bottom: 1rem;
+}
+
+.recap-body p:first-child {
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.recap-hidden p {
+  margin-bottom: 1rem;
+}
+
+.recap-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--orange);
+  font-size: 0.85rem;
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  padding: 0.35rem 0.75rem;
+  margin-top: 0.25rem;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.recap-toggle:hover {
+  background: rgba(215, 63, 9, 0.1);
+  border-color: var(--orange);
+}
+
+.recap-attribution {
+  margin-top: 1rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+}
+
+.recap-attribution a.inline-link {
+  color: var(--orange);
+}
+
+.recap-attribution a.inline-link:hover {
+  color: var(--orange-light);
+}
+
+/* Recap mobile: always show toggle; on desktop only show if > 3 paragraphs */
+@media (min-width: 769px) {
+  .recap-toggle {
+    display: none;
+  }
+  .recap-hidden {
+    display: block !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .recap-body {
+    font-size: 0.95rem;
+  }
+
+  .recap-body p:first-child {
+    font-size: 1rem;
+  }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,6 +6,7 @@
   let meets = [];
   let currentFilter = 'all';
   let currentView = 'season';
+  let _suppressHashPush = false;
 
   const EVENT_NAMES = {
     vault: 'Vault', bars: 'Bars', beam: 'Beam', floor: 'Floor', aa: 'All-Around'
@@ -26,6 +27,54 @@
     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'long', day: 'numeric', year: 'numeric' });
   }
 
+  function slugifyName(name) {
+    return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+  }
+
+  // ===== Hash Routing =====
+  function pushHash(hash) {
+    if (_suppressHashPush) return;
+    history.pushState(null, '', '#' + hash);
+  }
+
+  function readAndRouteHash() {
+    const hash = location.hash.replace('#', '');
+    if (!hash || hash === 'season') {
+      showView('season', true);
+      return;
+    }
+    if (hash.startsWith('meet/')) {
+      const meetId = hash.slice(5);
+      const m = meets.find(x => x.id === meetId);
+      if (m) { showMeetDetail(meetId, true); return; }
+    }
+    if (hash.startsWith('gymnast/')) {
+      const slug = hash.slice(8);
+      const profiles = getGymnastProfiles();
+      const p = profiles.find(pr => slugifyName(pr.name) === slug);
+      if (p) {
+        showView('gymnasts', true);
+        showGymnastProfile(p.name, true);
+        return;
+      }
+    }
+    if (hash.startsWith('leaderboard/')) {
+      const event = hash.slice(12);
+      showView('leaderboards', true);
+      renderLeaderboard(event);
+      return;
+    }
+    if (hash === 'gymnasts') { showView('gymnasts', true); return; }
+    if (hash === 'leaderboards') { showView('leaderboards', true); return; }
+    showView('season', true);
+  }
+
+  window.addEventListener('popstate', () => {
+    _suppressHashPush = true;
+    readAndRouteHash();
+    _suppressHashPush = false;
+  });
+
   // ===== Data Loading =====
   async function loadData() {
     try {
@@ -33,11 +82,9 @@
       meets = await res.json();
       document.getElementById('loading').style.display = 'none';
 
-      // Build search index and initialize search UI
       if (window.OSUSearch) {
         OSUSearch.buildIndex(meets);
         OSUSearch.createUI();
-        // Wire navigation callbacks
         OSUSearch.onGymnastSelect = function (name) {
           showView('gymnasts');
           showGymnastProfile(name);
@@ -59,7 +106,12 @@
         };
       }
 
-      showView('season');
+      // Route from hash or default to season
+      if (location.hash && location.hash !== '#') {
+        readAndRouteHash();
+      } else {
+        showView('season', true);
+      }
     } catch (err) {
       document.getElementById('loading').innerHTML =
         '<div class="empty-state"><div class="empty-icon">😕</div><p class="empty-text">Failed to load data. Is the server running?</p></div>';
@@ -67,7 +119,7 @@
   }
 
   // ===== Navigation =====
-  function showView(view) {
+  function showView(view, skipPush) {
     currentView = view;
     document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
     document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
@@ -77,9 +129,11 @@
     if (el) {
       el.style.display = 'block';
       el.style.animation = 'none';
-      el.offsetHeight; // trigger reflow
+      el.offsetHeight;
       el.style.animation = '';
     }
+
+    if (!skipPush) pushHash(view);
 
     if (view === 'season') renderSeason();
     else if (view === 'gymnasts') renderGymnasts();
@@ -117,12 +171,11 @@
 
     let dots = scores.map((s, i) => {
       const color = meets[i].result === 'W' ? '#2ecc71' : '#e74c3c';
-      return `<circle cx="${xScale(i).toFixed(1)}" cy="${yScale(s).toFixed(1)}" r="5" fill="${color}" stroke="var(--dark)" stroke-width="2">
+      return `<circle cx="${xScale(i).toFixed(1)}" cy="${yScale(s).toFixed(1)}" r="5" fill="${color}" stroke="var(--dark)" stroke-width="2" class="trend-dot" data-meet-id="${meets[i].id}" style="cursor:pointer;">
         <title>${formatDate(meets[i].date)}: ${s.toFixed(3)} (${meets[i].result})</title>
       </circle>`;
     }).join('');
 
-    // Y-axis labels
     const yTicks = 5;
     let yLabels = '';
     let yGridLines = '';
@@ -133,10 +186,9 @@
       yGridLines += `<line x1="${pad.left}" y1="${y}" x2="${w - pad.right}" y2="${y}" stroke="#333" stroke-width="0.5"/>`;
     }
 
-    // X-axis labels
     let xLabels = meets.map((m, i) => {
       const x = xScale(i);
-      return `<text x="${x}" y="${h - 5}" text-anchor="middle" fill="#999" font-size="9" font-family="Inter">${formatDate(m.date)}</text>`;
+      return `<text x="${x}" y="${h - 5}" text-anchor="middle" fill="#999" font-size="9" font-family="Inter" class="trend-dot" data-meet-id="${m.id}" style="cursor:pointer;">${formatDate(m.date)}</text>`;
     }).join('');
 
     container.innerHTML = `
@@ -148,6 +200,11 @@
         ${xLabels}
       </svg>
     `;
+
+    // Trend dot clicks
+    container.querySelectorAll('.trend-dot').forEach(el => {
+      el.addEventListener('click', () => showMeetDetail(el.dataset.meetId));
+    });
   }
 
   function renderMeetCards() {
@@ -164,7 +221,6 @@
       return;
     }
 
-    // Group quad meets together; non-quad meets appear as-is
     const rendered = [];
     const seenQuads = new Set();
 
@@ -172,7 +228,6 @@
       if (m.quadMeet && m.quadName) {
         if (!seenQuads.has(m.quadName)) {
           seenQuads.add(m.quadName);
-          // Gather all matchups for this quad
           const quadMeets = filtered.filter(q => q.quadName === m.quadName);
           rendered.push(renderQuadGroup(quadMeets));
         }
@@ -183,7 +238,6 @@
 
     grid.innerHTML = rendered.join('');
 
-    // Animate bars after render
     requestAnimationFrame(() => {
       grid.querySelectorAll('.event-bar-fill').forEach(bar => {
         const w = bar.style.width;
@@ -209,7 +263,7 @@
     }).join('');
 
     return `
-      <div class="meet-card" data-meet-id="${m.id}">
+      <div class="meet-card" data-meet-id="${m.id}" style="cursor:pointer;">
         <div class="meet-header">
           <div>
             <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''}</div>
@@ -267,17 +321,26 @@
   }
 
   // ===== Meet Detail =====
-  function showMeetDetail(meetId) {
+  function showMeetDetail(meetId, skipPush) {
     const meet = meets.find(m => m.id === meetId);
     if (!meet) return;
 
+    if (!skipPush) pushHash('meet/' + meetId);
+
     document.querySelectorAll('.view').forEach(v => v.style.display = 'none');
+    document.querySelectorAll('.nav-link, .bottom-nav-item').forEach(l => l.classList.remove('active'));
     const view = document.getElementById('view-meet');
     view.style.display = 'block';
 
-    const content = document.getElementById('meetDetailContent');
+    // Breadcrumb
+    const breadcrumb = `
+      <nav class="breadcrumb">
+        <a href="#" class="breadcrumb-link" data-nav="season">Season</a>
+        <span class="breadcrumb-sep">›</span>
+        <span class="breadcrumb-current">${meet.opponent} ${formatDate(meet.date)}</span>
+      </nav>`;
 
-    // Quad meet teams table
+    // Quad meet full standings table
     let teamsTable = '';
     if (meet.allTeams) {
       teamsTable = `
@@ -298,7 +361,7 @@
         </div>`;
     }
 
-    // Event detail cards with athlete lineups
+    // Event detail cards with clickable athlete names and event headers
     const eventCards = ['vault', 'bars', 'beam', 'floor'].map(event => {
       const eventAthletes = meet.athletes
         .filter(a => a.scores[event] !== undefined)
@@ -307,7 +370,7 @@
       const rows = eventAthletes.map((a, i) => `
         <tr>
           <td>${i + 1}</td>
-          <td>${a.name}</td>
+          <td><a href="#" class="inline-link gymnast-link" data-gymnast="${a.name}">${a.name}</a></td>
           <td class="score-cell">${a.scores[event].toFixed(3)}</td>
         </tr>`).join('');
 
@@ -317,9 +380,11 @@
 
       return `
         <div class="detail-event-card">
-          <div class="detail-event-title">${EVENT_NAMES[event]}</div>
+          <div class="detail-event-title">
+            <a href="#" class="inline-link event-link" data-event="${event}">${EVENT_NAMES[event]}</a>
+          </div>
           <div style="display:flex;justify-content:space-between;margin-bottom:0.5rem;">
-            <span style="color:var(--orange);font-family:Oswald;font-weight:600;">${osuScore.toFixed(3)}</span>
+            <a href="#" class="inline-link event-score-link" data-event="${event}" data-score="${osuScore}" style="font-family:Oswald;font-weight:600;color:var(--orange);">${osuScore.toFixed(3)}</a>
             <span style="color:var(--text-muted);font-size:0.85rem;">vs ${oppScore.toFixed(3)}</span>
           </div>
           <div class="event-bar-track" style="margin-bottom:0.75rem;">
@@ -332,13 +397,54 @@
         </div>`;
     }).join('');
 
+    // Meet recap section
+    let recapSection = '';
+    if (meet.recap) {
+      const paragraphs = meet.recap.trim().split(/\n\n+/).filter(p => p.trim());
+      const lede = paragraphs[0] || '';
+      const rest = paragraphs.slice(1);
+
+      // Mobile collapsible: first 3 paragraphs visible, rest hidden
+      const visibleParas = paragraphs.slice(0, 3).map(p => `<p>${p.trim()}</p>`).join('');
+      const hiddenParas = paragraphs.slice(3).map(p => `<p>${p.trim()}</p>`).join('');
+
+      recapSection = `
+        <div class="section-card recap-card">
+          <h2 class="section-title">📰 Meet Recap</h2>
+          <div class="recap-body">
+            <div class="recap-visible">${visibleParas}</div>
+            ${hiddenParas ? `
+              <div class="recap-hidden" id="recapHidden" style="display:none;">${hiddenParas}</div>
+              <button class="recap-toggle" id="recapToggle">Read more ▾</button>
+            ` : ''}
+          </div>
+          <div class="recap-attribution">
+            Source: <a href="${meet.recapUrl}" target="_blank" rel="noopener" class="inline-link">Oregon State Athletics</a>
+          </div>
+        </div>`;
+    }
+
+    // Location/home-away filter links
+    const locationText = meet.isHome
+      ? `<a href="#" class="inline-link location-link" data-filter="home">${meet.location}</a>`
+      : `<a href="#" class="inline-link location-link" data-filter="away">${meet.location}</a>`;
+
+    const dateMonth = new Date(meet.date + 'T12:00:00').toLocaleString('en-US', { month: 'long' });
+
+    const content = document.getElementById('meetDetailContent');
     content.innerHTML = `
+      ${breadcrumb}
       <div class="detail-hero">
         <div class="meet-header">
           <div>
-            <div class="meet-opponent" style="font-size:1.5rem;">vs ${meet.opponent}</div>
-            <div class="meet-date">${formatDateLong(meet.date)}</div>
-            <div class="meet-location">${meet.location}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
+            <div class="meet-opponent" style="font-size:1.5rem;">
+              vs <a href="#" class="inline-link opponent-link" data-opponent="${meet.opponent}">${meet.opponent}</a>
+              ${meet.isHome ? '<span class="badge badge-home">HOME</span>' : ''}
+            </div>
+            <div class="meet-date">
+              <a href="#" class="inline-link date-link" data-month="${dateMonth}">${formatDateLong(meet.date)}</a>
+            </div>
+            <div class="meet-location">${locationText}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
           </div>
           <span class="badge badge-${meet.result.toLowerCase()}" style="font-size:1rem;padding:0.3rem 0.8rem;">${meet.result}</span>
         </div>
@@ -349,9 +455,123 @@
         </div>
       </div>
       ${teamsTable}
+      ${recapSection}
       <h2 class="section-title" style="margin-bottom:1rem;">Event Breakdown</h2>
       <div class="detail-event-grid">${eventCards}</div>
     `;
+
+    // Wire up breadcrumb
+    content.querySelector('.breadcrumb-link[data-nav="season"]').addEventListener('click', e => {
+      e.preventDefault();
+      showView('season');
+    });
+
+    // Wire up gymnast links
+    content.querySelectorAll('.gymnast-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('gymnasts');
+        showGymnastProfile(el.dataset.gymnast);
+      });
+    });
+
+    // Wire up event links → leaderboard
+    content.querySelectorAll('.event-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('leaderboards');
+        renderLeaderboard(el.dataset.event);
+        pushHash('leaderboard/' + el.dataset.event);
+      });
+    });
+
+    // Wire up event score links → leaderboard
+    content.querySelectorAll('.event-score-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('leaderboards');
+        renderLeaderboard(el.dataset.event);
+        pushHash('leaderboard/' + el.dataset.event);
+      });
+    });
+
+    // Wire up opponent links → filtered season
+    content.querySelectorAll('.opponent-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('season');
+        // Filter by opponent using a custom filter
+        filterByOpponent(el.dataset.opponent);
+      });
+    });
+
+    // Wire up date links → season (no filter change, just scroll)
+    content.querySelectorAll('.date-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('season');
+      });
+    });
+
+    // Wire up location links → home/away filter
+    content.querySelectorAll('.location-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        currentFilter = el.dataset.filter;
+        showView('season');
+        document.querySelectorAll('.filter-btn').forEach(b => {
+          b.classList.toggle('active', b.dataset.filter === el.dataset.filter);
+        });
+        renderMeetCards();
+      });
+    });
+
+    // Wire up recap toggle
+    const recapToggle = content.querySelector('#recapToggle');
+    const recapHidden = content.querySelector('#recapHidden');
+    if (recapToggle && recapHidden) {
+      recapToggle.addEventListener('click', () => {
+        const expanded = recapHidden.style.display !== 'none';
+        recapHidden.style.display = expanded ? 'none' : 'block';
+        recapToggle.textContent = expanded ? 'Read more ▾' : 'Read less ▴';
+      });
+    }
+
+    // Animate bars
+    requestAnimationFrame(() => {
+      content.querySelectorAll('.event-bar-fill').forEach(bar => {
+        const w = bar.style.width;
+        bar.style.width = '0%';
+        requestAnimationFrame(() => { bar.style.width = w; });
+      });
+    });
+  }
+
+  function filterByOpponent(opponent) {
+    const grid = document.getElementById('meetsGrid');
+    // Show all meets vs this opponent
+    const filtered = meets.filter(m => m.opponent === opponent);
+
+    if (filtered.length === 0) {
+      renderMeetCards();
+      return;
+    }
+
+    // Reset filter UI
+    document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+    document.querySelector('.filter-btn[data-filter="all"]')?.classList.add('active');
+    currentFilter = 'all';
+
+    // Show filtered cards with a header
+    grid.innerHTML = `<div style="color:var(--text-muted);font-size:0.85rem;padding:0.5rem 0;margin-bottom:0.5rem;">
+      Showing all meets vs <strong style="color:var(--text)">${opponent}</strong>
+      <a href="#" id="clearOpponentFilter" style="color:var(--orange);margin-left:0.75rem;font-size:0.8rem;">Clear filter</a>
+    </div>` + filtered.map(m => renderMeetCard(m)).join('');
+
+    grid.querySelector('#clearOpponentFilter')?.addEventListener('click', e => {
+      e.preventDefault();
+      renderMeetCards();
+    });
   }
 
   // ===== Gymnasts =====
@@ -370,19 +590,21 @@
       });
     });
 
-    // Compute averages and bests
     Object.values(profiles).forEach(p => {
       p.averages = {};
       p.bests = {};
+      p.bestMeets = {};
       p.eventsList = Array.from(p.events);
 
       ['vault', 'bars', 'beam', 'floor', 'aa'].forEach(event => {
         const scores = p.meets
           .filter(m => m.scores[event] !== undefined)
-          .map(m => m.scores[event]);
+          .map(m => ({ score: m.scores[event], meetId: m.meetId }));
         if (scores.length > 0) {
-          p.averages[event] = scores.reduce((a, b) => a + b, 0) / scores.length;
-          p.bests[event] = Math.max(...scores);
+          p.averages[event] = scores.reduce((a, b) => a + b.score, 0) / scores.length;
+          const best = scores.reduce((a, b) => b.score > a.score ? b : a);
+          p.bests[event] = best.score;
+          p.bestMeets[event] = best.meetId;
         }
       });
 
@@ -417,7 +639,7 @@
       }).join('');
 
       return `
-        <div class="gymnast-card" data-gymnast="${p.name}">
+        <div class="gymnast-card" data-gymnast="${p.name}" style="cursor:pointer;">
           <div class="gymnast-name">${p.name}</div>
           <div class="gymnast-events">${eventBadges}</div>
           <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.5rem;">${p.totalMeets} meets</div>
@@ -426,30 +648,41 @@
     }).join('');
   }
 
-  function showGymnastProfile(name) {
+  function showGymnastProfile(name, skipPush) {
     const profiles = getGymnastProfiles();
     const p = profiles.find(pr => pr.name === name);
     if (!p) return;
+
+    if (!skipPush) pushHash('gymnast/' + slugifyName(name));
 
     document.getElementById('gymnastCards').style.display = 'none';
     const detail = document.getElementById('gymnastDetail');
     detail.style.display = 'block';
 
-    // Stats grid
+    // Breadcrumb
+    const breadcrumb = `
+      <nav class="breadcrumb">
+        <a href="#" class="breadcrumb-link" data-nav="gymnasts">Gymnasts</a>
+        <span class="breadcrumb-sep">›</span>
+        <span class="breadcrumb-current">${p.name}</span>
+      </nav>`;
+
     const statsGrid = ['vault', 'bars', 'beam', 'floor'].map(event => {
       if (!p.averages[event]) return '';
+      const pbMeetId = p.bestMeets[event];
       return `
         <div class="profile-stat">
           <div class="stat-value" style="color:var(--orange)">${p.averages[event].toFixed(3)}</div>
           <div class="stat-label">${EVENT_NAMES[event]} Avg</div>
         </div>
         <div class="profile-stat">
-          <div class="stat-value">${p.bests[event].toFixed(3)}</div>
+          <div class="stat-value">
+            <a href="#" class="inline-link pb-link" data-meet-id="${pbMeetId}">${p.bests[event].toFixed(3)}</a> ★
+          </div>
           <div class="stat-label">${EVENT_NAMES[event]} Best</div>
         </div>`;
     }).join('');
 
-    // Sparklines per event
     const sparklines = ['vault', 'bars', 'beam', 'floor'].map(event => {
       const eventMeets = p.meets.filter(m => m.scores[event] !== undefined);
       if (eventMeets.length < 2) return '';
@@ -462,18 +695,26 @@
         </div>`;
     }).join('');
 
-    // Meet history table
     const historyRows = p.meets.map(m => {
       const cells = ['vault', 'bars', 'beam', 'floor'].map(e => {
         if (m.scores[e] === undefined) return '<td style="color:var(--text-muted)">—</td>';
         const isBest = p.bests[e] === m.scores[e];
-        return `<td class="${isBest ? 'personal-best' : ''}">${m.scores[e].toFixed(3)}${isBest ? ' ★' : ''}</td>`;
+        return `<td class="${isBest ? 'personal-best' : ''}">
+          <a href="#" class="inline-link score-meet-link" data-meet-id="${m.meetId}">${m.scores[e].toFixed(3)}</a>${isBest ? ' <span class="pb-badge" data-meet-id="${m.meetId}">PB</span>' : ''}
+        </td>`;
       }).join('');
-      const aa = m.scores.aa ? `<td>${m.scores.aa.toFixed(3)}</td>` : '<td style="color:var(--text-muted)">—</td>';
-      return `<tr><td>${formatDate(m.date)}</td><td>${m.opponent}</td>${cells}${aa}</tr>`;
+      const aa = m.scores.aa
+        ? `<td><a href="#" class="inline-link score-meet-link" data-meet-id="${m.meetId}">${m.scores.aa.toFixed(3)}</a></td>`
+        : '<td style="color:var(--text-muted)">—</td>';
+      return `<tr>
+        <td>${formatDate(m.date)}</td>
+        <td><a href="#" class="inline-link meet-detail-link" data-meet-id="${m.meetId}">${m.opponent}</a></td>
+        ${cells}${aa}
+      </tr>`;
     }).join('');
 
     detail.innerHTML = `
+      ${breadcrumb}
       <div class="gymnast-profile">
         <button class="back-btn" id="backToGymnasts">← Back to Gymnasts</button>
         <div class="profile-header">
@@ -493,9 +734,35 @@
         </div>
       </div>`;
 
-    document.getElementById('backToGymnasts').addEventListener('click', () => {
+    // Wire back button
+    detail.querySelector('#backToGymnasts').addEventListener('click', () => {
+      pushHash('gymnasts');
       detail.style.display = 'none';
       document.getElementById('gymnastCards').style.display = 'grid';
+    });
+
+    // Wire breadcrumb
+    detail.querySelector('.breadcrumb-link[data-nav="gymnasts"]').addEventListener('click', e => {
+      e.preventDefault();
+      pushHash('gymnasts');
+      detail.style.display = 'none';
+      document.getElementById('gymnastCards').style.display = 'grid';
+    });
+
+    // Wire PB links → meet detail
+    detail.querySelectorAll('.pb-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showMeetDetail(el.dataset.meetId);
+      });
+    });
+
+    // Wire score-meet links → meet detail
+    detail.querySelectorAll('.score-meet-link, .meet-detail-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showMeetDetail(el.dataset.meetId);
+      });
     });
   }
 
@@ -556,11 +823,33 @@
       <div class="leaderboard-item">
         <div class="lb-rank ${i < 3 ? 'top-3' : ''}">${i + 1}</div>
         <div class="lb-info">
-          <div class="lb-name">${s.name}</div>
-          <div class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}</div>
+          <div class="lb-name">
+            <a href="#" class="inline-link gymnast-lb-link" data-gymnast="${s.name}">${s.name}</a>
+          </div>
+          <div class="lb-context">
+            ${formatDate(s.meetDate)} vs
+            <a href="#" class="inline-link meet-lb-link" data-meet-id="${s.meetId}">${s.opponent}</a>
+          </div>
         </div>
         <div class="lb-score">${s.score.toFixed(3)}</div>
       </div>`).join('');
+
+    // Wire leaderboard gymnast links
+    list.querySelectorAll('.gymnast-lb-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showView('gymnasts');
+        showGymnastProfile(el.dataset.gymnast);
+      });
+    });
+
+    // Wire leaderboard meet links
+    list.querySelectorAll('.meet-lb-link').forEach(el => {
+      el.addEventListener('click', e => {
+        e.preventDefault();
+        showMeetDetail(el.dataset.meetId);
+      });
+    });
   }
 
   // ===== Event Listeners =====
@@ -585,13 +874,13 @@
       });
     });
 
-    // Meet card click
+    // Meet card click (season view)
     document.getElementById('meetsGrid').addEventListener('click', e => {
       const card = e.target.closest('.meet-card');
       if (card) showMeetDetail(card.dataset.meetId);
     });
 
-    // Back button
+    // Back button on meet detail
     document.getElementById('backToSeason').addEventListener('click', () => showView('season'));
 
     // Gymnast search
@@ -605,10 +894,13 @@
       if (card) showGymnastProfile(card.dataset.gymnast);
     });
 
-    // Event tabs
+    // Event tabs (leaderboard)
     document.getElementById('eventTabs').addEventListener('click', e => {
       const tab = e.target.closest('.event-tab');
-      if (tab) renderLeaderboard(tab.dataset.event);
+      if (tab) {
+        renderLeaderboard(tab.dataset.event);
+        pushHash('leaderboard/' + tab.dataset.event);
+      }
     });
   });
 })();


### PR DESCRIPTION
## Summary

Addresses issue #6

### Part 1: Cross-linking Everything

- **Hash-based URL routing** — every view has a shareable URL:
  - `#season` → Season overview
  - `#meet/{id}` → Meet detail (e.g. `#meet/stanford-feb-27`)
  - `#gymnast/{slug}` → Gymnast profile (e.g. `#gymnast/sophia-esposito`)
  - `#leaderboard/{event}` → Leaderboard (e.g. `#leaderboard/vault`)
  - Browser back/forward work correctly via `pushState` + `popstate`

- **Meet detail page** — every element is now clickable:
  - Event names → Event Leaderboard for that event
  - Event scores (e.g. 49.300) → Event Leaderboard for that event
  - Gymnast names → Gymnast profile page
  - Opponent name → Season view filtered to all meets vs that opponent
  - Date → back to Season overview
  - Location → Season filtered to Home or Away

- **Leaderboard** — each row: gymnast name → profile, meet name → meet detail

- **Gymnast profile** — each score in history table → that meet's detail page; PB stat → PB meet detail

- **Score trend chart** — dots + x-axis labels are clickable → meet detail

- **Breadcrumbs** on meet detail (`Season › Stanford Feb 27`) and gymnast profile (`Gymnasts › Sophia Esposito`)

### Part 2: Meet Recaps

- Scraped all 10 recap articles from osubeavers.com using the official story body div
- Stored as `recap` (plain text) + `recapUrl` (source URL) in `data/meets.json` for all 16 meets
- Recap section renders on meet detail page with:
  - Readable typography (Inter, 16px, line-height 1.75, max-width 720px)
  - First paragraph styled slightly larger as the lede
  - Attribution link to Oregon State Athletics
  - **Mobile**: first 3 paragraphs shown, 'Read more ▾' button expands the rest
  - **Desktop**: full recap always visible

### Files changed
- `public/js/app.js` — full routing + linking + recap display
- `public/css/style.css` — breadcrumb, inline-link, recap card, PB badge styles
- `data/meets.json` — `recap` + `recapUrl` fields added to all 16 meet objects