### PR TITLE
feat: display gymnasts in competition order on meet detail lineups

### DIFF
--- a/data/meets.json
+++ b/data/meets.json
@@ -144,6 +144,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Katie Rude",
+          "score": 9.375
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 8.4
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        },
+        {
+          "position": 6,
+          "name": "Taylor DeVries",
+          "score": 9.925
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.8
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Paulina Vargas",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Taylor DeVries",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.8
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "UCLA",
@@ -328,6 +458,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Katie Rude",
+          "score": 9.375
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 8.4
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        },
+        {
+          "position": 6,
+          "name": "Taylor DeVries",
+          "score": 9.925
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.8
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Paulina Vargas",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Taylor DeVries",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.8
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "UCLA",
@@ -512,6 +772,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Katie Rude",
+          "score": 9.375
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 8.4
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        },
+        {
+          "position": 6,
+          "name": "Taylor DeVries",
+          "score": 9.925
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.8
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Paulina Vargas",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Taylor DeVries",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.8
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "UCLA",
@@ -550,376 +940,6 @@
         "floor": 48.675
       }
     ]
-  },
-  {
-    "id": "best-of-west-california-jan-3",
-    "date": "2026-01-03",
-    "opponent": "California",
-    "location": "Alaska Airlines Arena, Seattle, WA",
-    "isHome": false,
-    "result": "L",
-    "osuScore": 195.55,
-    "opponentScore": 196.0,
-    "quadMeet": true,
-    "quadName": "Best of the West Quad",
-    "events": {
-      "vault": {
-        "osu": 48.85,
-        "opponent": 48.975
-      },
-      "bars": {
-        "osu": 48.95,
-        "opponent": 49.275
-      },
-      "beam": {
-        "osu": 49.075,
-        "opponent": 49.025
-      },
-      "floor": {
-        "osu": 48.675,
-        "opponent": 48.725
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75
-        }
-      },
-      {
-        "name": "Katie Rude",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.375
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725,
-          "bars": 9.75,
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.675,
-          "beam": 9.7
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.825,
-          "floor": 9.8
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.7
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.4,
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.75,
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Taylor DeVries",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.925,
-          "floor": 9.65
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.8
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Sophia Kaloudis",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "UCLA",
-        "rank": 1,
-        "total": 196.975,
-        "vault": 49.15,
-        "bars": 49.225,
-        "beam": 49.525,
-        "floor": 49.075
-      },
-      {
-        "team": "California",
-        "rank": 2,
-        "total": 196.0,
-        "vault": 48.975,
-        "bars": 49.275,
-        "beam": 49.025,
-        "floor": 48.725
-      },
-      {
-        "team": "Washington",
-        "rank": 3,
-        "total": 195.625,
-        "vault": 48.675,
-        "bars": 48.725,
-        "beam": 49.275,
-        "floor": 48.95
-      },
-      {
-        "team": "Oregon State",
-        "rank": 4,
-        "total": 195.55,
-        "vault": 48.85,
-        "bars": 48.95,
-        "beam": 49.075,
-        "floor": 48.675
-      }
-    ]
-  },
-  {
-    "id": "best-of-west-washington-jan-3",
-    "date": "2026-01-03",
-    "opponent": "Washington",
-    "location": "Alaska Airlines Arena, Seattle, WA",
-    "isHome": false,
-    "result": "L",
-    "osuScore": 195.55,
-    "opponentScore": 195.625,
-    "quadMeet": true,
-    "quadName": "Best of the West Quad",
-    "events": {
-      "vault": {
-        "osu": 48.85,
-        "opponent": 48.675
-      },
-      "bars": {
-        "osu": 48.95,
-        "opponent": 48.725
-      },
-      "beam": {
-        "osu": 49.075,
-        "opponent": 49.275
-      },
-      "floor": {
-        "osu": 48.675,
-        "opponent": 48.95
-      }
-    },
-    "athletes": [
-      {
-        "name": "Kyanna Crabb",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.75
-        }
-      },
-      {
-        "name": "Katie Rude",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.375
-        }
-      },
-      {
-        "name": "Savannah Miller",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.725,
-          "bars": 9.75,
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Olivia Buckner",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.675,
-          "beam": 9.7
-        }
-      },
-      {
-        "name": "Sophia Esposito",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "beam": 9.825,
-          "floor": 9.8
-        }
-      },
-      {
-        "name": "Camryn Richardson",
-        "team": "Oregon State",
-        "scores": {
-          "vault": 9.85,
-          "bars": 9.825
-        }
-      },
-      {
-        "name": "Francesca Caso",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.7
-        }
-      },
-      {
-        "name": "Kaylee Cheek",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 8.4,
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Ellie Weaver",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.75,
-          "beam": 9.75
-        }
-      },
-      {
-        "name": "Taylor DeVries",
-        "team": "Oregon State",
-        "scores": {
-          "bars": 9.925,
-          "floor": 9.65
-        }
-      },
-      {
-        "name": "Mia Heather",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.8
-        }
-      },
-      {
-        "name": "Lauren Letzsch",
-        "team": "Oregon State",
-        "scores": {
-          "beam": 9.85
-        }
-      },
-      {
-        "name": "Sophia Kaloudis",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.775
-        }
-      },
-      {
-        "name": "Paulina Vargas",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      },
-      {
-        "name": "Reina Marchal",
-        "team": "Oregon State",
-        "scores": {
-          "floor": 9.7
-        }
-      }
-    ],
-    "allTeams": [
-      {
-        "team": "UCLA",
-        "rank": 1,
-        "total": 196.975,
-        "vault": 49.15,
-        "bars": 49.225,
-        "beam": 49.525,
-        "floor": 49.075
-      },
-      {
-        "team": "California",
-        "rank": 2,
-        "total": 196.0,
-        "vault": 48.975,
-        "bars": 49.275,
-        "beam": 49.025,
-        "floor": 48.725
-      },
-      {
-        "team": "Washington",
-        "rank": 3,
-        "total": 195.625,
-        "vault": 48.675,
-        "bars": 48.725,
-        "beam": 49.275,
-        "floor": 48.95
-      },
-      {
-        "team": "Oregon State",
-        "rank": 4,
-        "total": 195.55,
-        "vault": 48.85,
-        "bars": 48.95,
-        "beam": 49.075,
-        "floor": 48.675
-      }
-    ],
-    "recapUrl": "https://osubeavers.com/news/2026/1/3/womens-gymnastics-espositos-strong-meet-helps-beavers-at-best-of-the-west-quad",
-    "recap": "SEATTLE, Wash. \u2013 Oregon State gymnastics opened its 2026 season on Saturday, posting a 195.550 to finish in fourth place against No. 20 California, No. 4 UCLA and hosts Washington.\n\r\n \n\r\nSophia Esposito finished with a trio of 9.800-plus scores, earning a 9.825 to lead off the beam lineup before also scoring a 9.800 on floor and 9.850 for her vault. Now a junior, Esposito is coming off a strong sophomore campaign that included a perfect 39 hits on 39 routines.\n\r\n \n\r\nTaylor DeVries was credited with the team's first 9.900-plus score of 2026, earning a 9.925 for her bars routine. Now in her junior season, DeVries came within striking distance of her career high, 9.950, which was set against Arizona State back in 2024. With a 9.925, DeVries also tied UCLA's Jordan Chiles and Cal's Tonya Paulsson for the meet's highest score, marking the Beavers' first event title of the year.\n\r\n \n\r\nCamryn Richardson, competing in her first meet as a Beaver, was given a pair of 9.825 or better scores, tying with Esposito for the highest mark on vault with a 9.850 before earning a 9.825 on bars, while Kaylee Cheek was given a 9.850 in her first routine at the collegiate level, which came during the Beavers' opening rotation on beam.\n\r\n \n\r\nThat first rotation, beam, proved to be the team's strongest of the meet, counting four 9.800-plus scores. Esposito's 9.825 was followed by Cheek's 9.850 which set the stage for a Mia Heather 9.800 and Lauren Letzsch 9.850; Ellie Weaver competed in the six spot and was given a 9.750 as the team posted a 49.075 rotation score.\n\r\n \n\r\nOregon State gymnastics returns to action next week, traveling to Provo, Utah, to face BYU. Action at the Marriott Center is slated to begin at 7 p.m. MT / 6 p.m. PT."
   },
   {
     "id": "byu-jan-9",
@@ -1064,9 +1084,137 @@
         }
       }
     ],
-    "attendance": "4,002",
-    "recapUrl": "https://osubeavers.com/news/2026/1/9/womens-gymnastics-strong-foor-rotation-not-enough-in-loss-at-byu",
-    "recap": "PROVO, Utah \u2013 Oregon State gymnastics tallied the highest rotation score of either team in its dual against BYU, a 49.200 on floor exercise, but that wasn't enough as the Beavers finished with a 194.525 and fell to the Cougars on Friday inside the Marriott Center.\n\r\n \n\r\nEllie Weaver had a great meet for the Beavers in Provo, earning a 9.800 on bars in the team's first rotation before posting a 9.850 in the anchor spot on beam, which OSU competed in the fourth and final rotation. For the Vancouver, Wash., native, her performance was a near tenth of a point average improvement from last week, having posted a pair of 9.750s in Seattle.\n\r\n \n\r\nSophia Esposito won her first event title of the season on Friday, earning a 9.900 on floor to tie for the meet's highest score, also adding a 9.800 for her vault. Esposito, who earned a trio of 9.800-plus scores last weekend, also competed on beam along with Lauren Letzsch, who earned her second 9.800-plus score in as many weeks.\n\r\n \n\r\nUtah natives Olivia Buckner and Kaylee Cheek both competed close to home, with Buckner earning a 9.800 for her vault and Cheek hitting on both routines; Camryn Richardson added a 9.800 for her bars routine and was also given a 9.750 in her first floor exercise appearance of the season.\n\r\n \n\r\nThe Beaver floor lineup earned the highest rotation score of either team in Friday's competition, combining for a 49.200. Paulina Vargas scored a 9.825 that was followed by Richardson's 9.750, setting the stage for the back half of the lineup, which featured a Savannah Miller 9.875, Reina Marchal 9.850 and Esposito's 9.900.\n\r\n \n\r\nOregon State gymnastics returns home for its next two meets, hosting Sacramento State (Jan. 16, 7 p.m.) and Utah State (Jan. 25, 1 p.m.). Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.675
+        },
+        {
+          "position": 2,
+          "name": "Katie Rude",
+          "score": 8.925
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.675
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.8
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.8
+        },
+        {
+          "position": 6,
+          "name": "Camryn Richardson",
+          "score": 8.95
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.675
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.75
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.675
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.8
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.8
+        },
+        {
+          "position": 6,
+          "name": "Taylor DeVries",
+          "score": 9.175
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.65
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.5
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.65
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.8
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.85
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Paulina Vargas",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Camryn Richardson",
+          "score": 9.75
+        },
+        {
+          "position": 4,
+          "name": "Savannah Miller",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        }
+      ]
+    },
+    "attendance": "4,002"
   },
   {
     "id": "sac-state-jan-16",
@@ -1200,9 +1348,137 @@
         }
       }
     ],
-    "attendance": "3,310",
-    "recapUrl": "https://osubeavers.com/news/2026/1/16/womens-gymnastics-espositos-39-500-helps-beavers-to-home-victory",
-    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito put up a pair of 9.900-plus scores on her way to a 39.500 in the all-around, helping the Oregon State Beavers defeat Sacramento State 196.375-193.675 at Gill Coliseum.\n\r\n \n\r\nEsposito started the meet with a 9.850 during the Beavers' vault rotation and followed it up with a new career high on bars, 9.900, before a 9.825 on beam set the stage for another 9.900-plus, earning a 9.925 for her floor exercise routine. Friday's floor score marked Esposito's second-consecutive week finishing with the meet's highest score on that event.\n\r\n \n\r\nKyanna Crabb led the entire meet off with a 9.875 in the first spot of OSU's vault lineup, earning a 9.900 from judge two and setting a new Oregon State career high in the process. Originally from Vancouver, Wash., Crabb has vaulted and completed an exhibition routine on floor in every single meet this season, and earned a 9.925 for her exhibition on Friday.\n\r\n \n\r\nEllie Weaver set a new career high in the meet's second rotation, earning a 9.950 on the uneven bars while anchoring the lineup, surpassing the 9.925 she set against Utah on March 11, 2023; the Battle Ground, Wash., native also competed on the beam, earning a 9.775, moving her beam average to 9.792 on the season while improving to a 9.833 average on the uneven bars.\n\r\n \n\r\nOlivia Buckner earned a pair of 9.875s on beam and floor, with the floor score setting a new personal best. Lauren Letzsch went 9.875 on beam while Savannah Miller earned a 9.875 on her floor routine for the second time in as many weeks.\n\r\n \n\r\nOSU's floor exercise lineup exceled against the Hornets, led off by Sophia Kaloudis' career-best 9.850 that was followed by a Paulina Vargas 9.825 and the 9.875s by Buckner and Miller; Esposito rounded out the rotation with her 9.925 to help the Beavers to a 49.350 rotation score, which is the highest on the season.\n\r\n \n\r\nThe Beavers improved in every single rotation, starting with a. 48.850 and progressing to a 49.050 bars score and 49.125 beam before floor exercise in the fourth.\n\r\n \n\r\nOregon State gymnastics stays home for its next meet, hosting Utah State next Sunday, Jan. 25. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.875
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.75
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Katie Rude",
+          "score": 8.9
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.8
+        },
+        {
+          "position": 2,
+          "name": "Sophia Kaloudis",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        },
+        {
+          "position": 4,
+          "name": "Kaylee Cheek",
+          "score": 9.725
+        },
+        {
+          "position": 5,
+          "name": "Francesca Caso",
+          "score": 9.2
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.95
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.875
+        },
+        {
+          "position": 3,
+          "name": "Sophia Kaloudis",
+          "score": 9.65
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.875
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.775
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Paulina Vargas",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.875
+        },
+        {
+          "position": 4,
+          "name": "Savannah Miller",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.925
+        }
+      ]
+    },
+    "attendance": "3,310"
   },
   {
     "id": "utah-state-jan-25",
@@ -1329,9 +1605,137 @@
         }
       }
     ],
-    "attendance": "3,651",
-    "recapUrl": "https://osubeavers.com/news/2026/1/25/womens-gymnastics-beaver-bars-set-the-tone-in-victory-over-23rd-ranked-utah-state",
-    "recap": "CORVALLIS, Ore. \u2013 Oregon State Gymnastics defeated the No. 23 Utah State Aggies on Sunday inside Gill Coliseum, posting a season-high 196.600 to secure a second-consecutive home victory.\n\r\n\n\r\nOSU's bars lineup was pivotal in the win, posting a season-high score for a single rotation with five scores tallying a 49.425, counting no lower than a 9.800 and posting a trio of 9.900-plus scores.\n\r\n \n\r\nFrancesca Caso, competing in the two spot, tied her career high with a 9.900 before Camryn Richardson and Ellie Weaver ended the rotation with back-to-back 9.925s; Sophia Esposito scored a 9.800 and Kaylee Cheek set a new season and career high thanks to a 9.875.\n\r\n \n\r\nFor Richardson, the 9.925 was a new career high and earned her first career event title thanks to Sunday's tie with Weaver, while Weaver has now won back-to-back event titles on the uneven bars after a 9.950 against Sacramento State last week. Esposito's bars routine helped fuel a second all-around title in as many weeks, also earning scores of 9.825 (VT), 9.850 (BB) and 9.750 (FX) to finish with a 39.225.\n\r\n\n\r\nOlivia Buckner also won her second event title of the year thanks to a 9.850 vault score, later adding a 9.800 during the team's third rotation on beam. Sunday's vault marked a new season high for the Riverton, Utah, native, who had earned a 9.800 at BYU two weeks ago.\n\r\n \n\r\nMia Heather's 9.900 on the balance beam was the meet's highest score on that event, earning a raucous response from Beaver faithful in attendance while surpassing the 9.825 scored last season in Tuscaloosa, Ala., at the NCAA Regional. The beam score also continued a strong start to Heather's collegiate career, having now hit on each of the seven routines she's completed as a Beav.\n\r\n \n\r\nPaulina Vargas led off the final rotation with a career-best 9.875 on floor while Reina Marchal earned her second 9.800-plus score in four routines this season, scoring a 9.825, while Savannah Miller tied her career high on that event thanks a 9.900 - her ninth time posting a 9.900.\n\r\n \n\r\nOregon State gymnastics is on the road for its next two meets, heading to face the Alabama Crimson Tide in Tuscaloosa next week and then to Boise, Idaho, on Feb. 6 before returning home Feb. 14 for another Pac-12 preview against Southern Utah, which is scheduled for Feb. 14 at 2 p.m. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventatAlabamaL, 195.825-197.450Jan 30 (Fri)\n\n 4:30 p.m.RecapResultsSECN+PreviewLive Scoring History Full Schedule<h3 name=\"h3\" class=\"s-heading__m"
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.8
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.65
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.7
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Olivia Buckner",
+          "score": 9.85
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.9
+        },
+        {
+          "position": 3,
+          "name": "Sophia Esposito",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Kaylee Cheek",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.925
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.925
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.8
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.625
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.9
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.775
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.775
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.875
+        },
+        {
+          "position": 2,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.9
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.75
+        }
+      ]
+    },
+    "attendance": "3,651"
   },
   {
     "id": "alabama-jan-30",
@@ -1606,6 +2010,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.725
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.875
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.525
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.5
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.675
+        },
+        {
+          "position": 2,
+          "name": "Kyanna Crabb",
+          "score": 8.475
+        },
+        {
+          "position": 3,
+          "name": "Taylor DeVries",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "San Jose State",
@@ -1779,6 +2313,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.725
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.875
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.525
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.5
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.675
+        },
+        {
+          "position": 2,
+          "name": "Kyanna Crabb",
+          "score": 8.475
+        },
+        {
+          "position": 3,
+          "name": "Taylor DeVries",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "San Jose State",
@@ -1952,6 +2616,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.7
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.85
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.725
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.875
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Sophia Esposito",
+          "score": 9.775
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.525
+        },
+        {
+          "position": 4,
+          "name": "Mia Heather",
+          "score": 9.65
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.5
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.675
+        },
+        {
+          "position": 2,
+          "name": "Kyanna Crabb",
+          "score": 8.475
+        },
+        {
+          "position": 3,
+          "name": "Taylor DeVries",
+          "score": 9.7
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 5,
+          "name": "Reina Marchal",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "San Jose State",
@@ -2124,9 +2918,137 @@
         }
       }
     ],
-    "attendance": "3,954",
-    "recapUrl": "https://osubeavers.com/news/2026/2/14/womens-gymnastics-season-highs-on-beam-and-floor-not-enough-in-loss-to-suu",
-    "recap": "CORVALLIS, Ore. \u2013 Despite posting season-best marks on beam (49.350) and floor (49.400), Oregon State Gymnastics fell to the Southern Utah Flippin' Birds on Saturday, finishing with a 196.300 against a future Pac-12 opponent inside legendary Gill Coliseum.\n\r\n \n\r\nOlivia Buckner had a fantastic meet against SUU, finishing with scores of 9.875 (VT), 9.825 (BB) and 9.875 (FX). The vault score set a new season high and her 9.875 on floor tied a season and career high mark; Saturday's performance was also her first time with three or more 9.800-plus scores since the NCAA Tuscaloosa Regional Semifinal last spring.\n\r\n \n\r\nSophia Esposito's incredible performances in the all-around continued Saturday, finishing with a 39.450 that included bars and floor scores which tied a career high. The Melville, N.Y., native started her meet by vaulting to a 9.775 before earning her first 9.900 on the uneven bars, using that momentum to post a 9.825 for the beam team and rounding out the meet with another 9.900-plus, this time a 9.950 on floor.\n\r\n \n\r\nEsposito, who's now competed all-around in five-straight competitions, won event titles on bars and floor, and has now posted a 9.900 or better in consecutive weeks after earning a 9.900 for her floor routine in Boise.\n\r\n \n\r\nLauren Letzsch was also in the 9.900s on Saturday, earning a season high 9.925 for OSU's beam lineup that came within striking distance of her career high, which is 9.950. Letzsch, who entered the meet as the team-leader in average beam score, has now won three event titles this season that event.\n\r\n \n\r\nKaylee Cheek was also part of the 9.900 club, also earning her 9.900 on the balance beam. A true freshman from Spanish Fork, Utah, Cheek has competed on beam and bars in every meet this season and has earned a 9.850 or better for her beam routine on three different occasions.\n\r\n \n\r\nThat third rotation saw OSU score a season-high 49.350 on the beam, starting with a pair of 9.825s by Mia Heather and Buckner. After Cheek's 9.900, Ellie Weaver stepped up with a 9.875 to set the stage for Letzsch's 9.925 and an Esposito 9.825. Entering the meet as the 21st-ranked beam lineup in the country, the rotation score bested the lineup's 49.125 score against Sacramento State on Jan. 16.\n\r\n \n\r\nOSU's floor group stole the show, however, putting up a 49.400 that counted no lower than a 9.825. Sophia Kaloudis was back in the lineup and earned that 9.825 before Buckner's 9.875 and a Reina Marchal 9.900 that set a new season and career high. Savannah Miller posted her fifth-consecutive 9.850 or better with an even 9.850 before Esposito's 9.950.\n\r\n \n\r\nSouthern Utah took the win with a 196.825.\n\r\n \n\r\nBeaver Gymnastics is on the road for its next meet, traveling to Denton, Texas, to compete against Texas Woman's and Kent State and Kent State in the TWU Tri Meet, returning home the following week to host Stanford Feb. 27. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventatTexas Woman'sL, 195.775-195.975Feb 22 (Sun)\n\n 12 p.m.RecapResultsWatchPreviewLive stats History Full Schedule"
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.725
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.725
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.775
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.025
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.85
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.225
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.875
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.825
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Mia Heather",
+          "score": 9.825
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.9
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.925
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.8
+        },
+        {
+          "position": 2,
+          "name": "Sophia Kaloudis",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.875
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.9
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.95
+        }
+      ]
+    },
+    "attendance": "3,954"
   },
   {
     "id": "twu-quad-twu-feb-22",
@@ -2261,6 +3183,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.75
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Francesca Caso",
+          "score": 9.55
+        },
+        {
+          "position": 2,
+          "name": "Kaylee Cheek",
+          "score": 8.0
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.9
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Mia Heather",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.825
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.225
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.7
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.6
+        },
+        {
+          "position": 2,
+          "name": "Taylor DeVries",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.875
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "TWU",
@@ -2433,6 +3485,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.75
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Francesca Caso",
+          "score": 9.55
+        },
+        {
+          "position": 2,
+          "name": "Kaylee Cheek",
+          "score": 8.0
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.9
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Mia Heather",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.825
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.225
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.7
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.6
+        },
+        {
+          "position": 2,
+          "name": "Taylor DeVries",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.875
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "TWU",
@@ -2475,12 +3657,12 @@
   {
     "id": "twu-quad-kent-state-feb-22",
     "date": "2026-02-22",
-    "opponent": "TWU",
+    "opponent": "Kent State",
     "location": "Kitty Magee Arena, Denton, TX",
     "isHome": false,
-    "result": "L",
+    "result": "W",
     "osuScore": 195.775,
-    "opponentScore": 195.975,
+    "opponentScore": 195.075,
     "quadMeet": true,
     "quadName": "TWU Quad",
     "events": {
@@ -2490,15 +3672,15 @@
       },
       "bars": {
         "osu": 48.9,
-        "opponent": 48.95
+        "opponent": 49.0
       },
       "beam": {
         "osu": 48.9,
-        "opponent": 49.025
+        "opponent": 48.325
       },
       "floor": {
         "osu": 49.0,
-        "opponent": 49.075
+        "opponent": 48.825
       }
     },
     "athletes": [
@@ -2605,6 +3787,136 @@
         }
       }
     ],
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.75
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.775
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Francesca Caso",
+          "score": 9.55
+        },
+        {
+          "position": 2,
+          "name": "Kaylee Cheek",
+          "score": 8.0
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.825
+        },
+        {
+          "position": 5,
+          "name": "Camryn Richardson",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Ellie Weaver",
+          "score": 9.9
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Mia Heather",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.825
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.225
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.85
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.7
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Paulina Vargas",
+          "score": 9.6
+        },
+        {
+          "position": 2,
+          "name": "Taylor DeVries",
+          "score": 9.675
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.775
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.85
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.825
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.875
+        }
+      ]
+    },
     "allTeams": [
       {
         "team": "TWU",
@@ -2642,9 +3954,7 @@
         "beam": 48.325,
         "floor": 48.825
       }
-    ],
-    "recapUrl": "https://osubeavers.com/news/2026/2/22/womens-gymnastics-beavers-finish-second-at-twu-quad-meet",
-    "recap": "DENTON, Texas \u2013 Oregon State gymnastics placed second in a quad meet on Sunday, tallying a 195.775 to finish behind host Texas Woman's (195.975) but ahead of Arizona State (195.550) and Kent State (195.075) inside Kitty Magee Arena.\n\r\n \n\r\nSophia Esposito posted a 39.225 the all-around, which included a pair of 9.825s (VT, UB) and a 9.875 on floor that came on the heels of her season-high 9.950 against Southern Utah last week. A junior from Melville, N.Y., Esposito has competed in the all-around in each of her last six appearances and won a share of the floor exercise event title to make it nine on the season \u2013 five of which have come on that event.\n\r\n \n\r\nOlivia Buckner also won an event title for the second-consecutive week thanks to a 9.850 vault score, adding 9.775s on beam and floor. The Riverton, Utah, native has exceled particularly on vault in recent weeks, as Sunday's 9.850 is her fourth 9.825 or better in the last five weeks, which includes a 9.850 against Utah State and last week's 9.875.\n\r\n \n\r\nAfter an early fall, OSU's bars lineup responded in a big way, rattling off a trio of 9.800-plus scores to finish he rotation. Esposito's 9.825 in the four spot setup Texas native Camryn Richardson, who earned a 9.850, before Ellie Weaver earned the team's highest score of the meet with a 9.900 that tied for the meet's highest score.\n\r\n \n\r\nFor Weaver, the event title win was her fourth on the season, all of which have come on bars, and made it three 9.900 or better bars scores this season, while Richardson's strong showing is her third-straight meet with a 9.825 or better and increases her season average to 9.836.\n\r\n \n\r\nOn beam, Kaylee Cheek (9.825) and Lauren Letzsch (9.850) led the way, while Reina Marchal (9.850) and Savannah Miller (9.825) combined with Esposito's 9.875 to propel OSU's floor lineup to the team's highest rotation score of the meet, a 49.000.\n\r\n \n\r\nOregon State returns home for a meet Feb. 27, hosting Stanford at 7 p.m. inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix.\n\r\n Skip Ad Next EventvsStanfordL, 197.250-198.150Feb 27 (Fri)\n\n 7 p.m.RecapResultsPac-12 InsiderPreviewLive Scoring Tickets History Full Schedule<div data-test-id"
+    ]
   },
   {
     "id": "stanford-feb-27",
@@ -2778,9 +4088,137 @@
         }
       }
     ],
-    "attendance": "3,617",
-    "recapUrl": "https://osubeavers.com/news/2026/2/27/womens-gymnastics-espositos-career-night-leads-season-high-score",
-    "recap": "CORVALLIS, Ore. \u2013 Sophia Esposito earned four 9.900 or better scores on her way to a career-high 39.700 in the all-around as Oregon State Gymnastics' season-best 197.250 wasn't enough, falling to No. 10 Stanford's 198.150 inside legendary Gill Coliseum.\n\r\n \n\r\nEsposito bested her previous career high of 39.525 thanks to a pair of career highs on vault (9.950) and beam (9.950) to go with 9.9.00s on bars and floor. The Melville, N.Y., native has been tremendous as a junior in 2026, hitting on each of her 34 routines this season and has now posted a 9.900 or better on at least one event in three of her last four meets.\n\r\n \n\r\nOlivia Buckner had another fantastic performance, vaulting her way to a 9.900 before adding a 9.825 on the beam and 9.875 for her floor routine. With her vault, Buckner has now tallied a 9.850 or better on that event in each of the last three competitions, while the floor score tied a career high.\n\r\n \n\r\nBuckner and Esposito were both part of a strong showing for the vault lineup, who set a season-high rotation score with a 49.300. Led off by Reina Marchal's 9.775, Savannah Miller was given a 9.800 before Buckner and Esposito went back-to-back with their 9.900 and 9.950; Katie Rude finished the Beavers' scoring with a 9.875 that set a new career high.\n\r\n \n\r\nEllie Weaver led the way during OSU's bars rotation with a 9.925, her second-straight week with a 9.900 or better on that event, while the rotation also featured Esposito's 9.900, a Taylor DeVries 9.825 and Francesca Caso 9.800. \n\r\n \n\r\nThe Beaver beam lineup also set a new season-best rotation score, counting a pair of 9.900 or better scores and no lower than a 9.800. Led off by a Mia Heather 9.875 that was followed immediately by Buckner's 9.825 and a Kaylee Cheek 9.800, Lauren Letzsch posted her second 9.925 in the last three meets before Esposito's 9.950 to round out the team's 49.375 combined score on beam.\n\r\n \n\r\nSophia Kaloudis was back in the floor lineup and led it off with a career high-tying 9.850 before Buckner, Marchal and Miller rattled off three-straight 9.875s and Esposito's 9.900.\n\r\n \n\r\nFor Marchal, the 9.875 comes on the heels of a 9.850 last week in Texas and 9.900 the weekend before, while Miller's makes it six 9.850 or better scores in her last seven appearances.\n\r\n \n\r\nOregon State gymnastics is back on the road next weekend, heading to Logan, Utah, to face Utah State, returning home to face Denver on March 14 inside legendary Gill Coliseum. Tickets are available and can be purchased by calling the Beaver Ticket Office at 1-800-GO-BEAVS or visiting https://beav.es/GymnasticsTix."
+    "lineups": {
+      "vault": [
+        {
+          "position": 1,
+          "name": "Kyanna Crabb",
+          "score": 9.725
+        },
+        {
+          "position": 2,
+          "name": "Reina Marchal",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Savannah Miller",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Olivia Buckner",
+          "score": 9.9
+        },
+        {
+          "position": 5,
+          "name": "Sophia Esposito",
+          "score": 9.95
+        },
+        {
+          "position": 6,
+          "name": "Katie Rude",
+          "score": 9.875
+        }
+      ],
+      "bars": [
+        {
+          "position": 1,
+          "name": "Savannah Miller",
+          "score": 9.75
+        },
+        {
+          "position": 2,
+          "name": "Francesca Caso",
+          "score": 9.8
+        },
+        {
+          "position": 3,
+          "name": "Taylor DeVries",
+          "score": 9.825
+        },
+        {
+          "position": 4,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        },
+        {
+          "position": 5,
+          "name": "Ellie Weaver",
+          "score": 9.925
+        },
+        {
+          "position": 6,
+          "name": "Kaylee Cheek",
+          "score": 9.05
+        }
+      ],
+      "beam": [
+        {
+          "position": 1,
+          "name": "Mia Heather",
+          "score": 9.875
+        },
+        {
+          "position": 2,
+          "name": "Olivia Buckner",
+          "score": 9.825
+        },
+        {
+          "position": 3,
+          "name": "Kaylee Cheek",
+          "score": 9.8
+        },
+        {
+          "position": 4,
+          "name": "Ellie Weaver",
+          "score": 9.75
+        },
+        {
+          "position": 5,
+          "name": "Lauren Letzsch",
+          "score": 9.925
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.95
+        }
+      ],
+      "floor": [
+        {
+          "position": 1,
+          "name": "Sophia Kaloudis",
+          "score": 9.85
+        },
+        {
+          "position": 2,
+          "name": "Taylor DeVries",
+          "score": 9.775
+        },
+        {
+          "position": 3,
+          "name": "Olivia Buckner",
+          "score": 9.875
+        },
+        {
+          "position": 4,
+          "name": "Reina Marchal",
+          "score": 9.875
+        },
+        {
+          "position": 5,
+          "name": "Savannah Miller",
+          "score": 9.875
+        },
+        {
+          "position": 6,
+          "name": "Sophia Esposito",
+          "score": 9.9
+        }
+      ]
+    },
+    "attendance": "3,617"
   },
   {
     "id": "utah-state-mar-6",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -531,6 +531,11 @@ main {
   text-align: right;
 }
 
+.lineup-table .score-cell.score-top {
+  color: var(--orange);
+  font-weight: 700;
+}
+
 /* ===== Gymnast Search ===== */
 .search-container {
   margin-bottom: 1.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -498,20 +498,36 @@
 
     // Event detail cards with athlete lineups
     const eventCards = ['vault', 'bars', 'beam', 'floor'].map(event => {
-      const eventAthletes = meet.athletes
-        .filter(a => a.scores[event] !== undefined)
-        .sort((a, b) => b.scores[event] - a.scores[event]);
-
-      const rows = eventAthletes.map((a, i) => `
-        <tr>
-          <td>${i + 1}</td>
-          <td>${a.name}</td>
-          <td class="score-cell">${a.scores[event].toFixed(3)}</td>
-        </tr>`).join('');
-
       const osuScore = meet.events[event].osu;
       const oppScore = meet.events[event].opponent;
       const barPct = ((osuScore / 50) * 100).toFixed(1);
+
+      let rows;
+      if (meet.lineups && meet.lineups[event] && meet.lineups[event].length > 0) {
+        // Render in competition order using lineup data
+        const lineup = meet.lineups[event];
+        const topScore = Math.max(...lineup.map(e => e.score));
+        rows = lineup.map(entry => {
+          const isTop = entry.score === topScore;
+          return `
+            <tr>
+              <td style="color:#aaa;font-size:0.75rem;font-family:monospace;width:1.5rem;">${entry.position}</td>
+              <td>${entry.name}</td>
+              <td class="score-cell${isTop ? ' score-top' : ''}">${entry.score.toFixed(3)}</td>
+            </tr>`;
+        }).join('');
+      } else {
+        // Fallback: sort by score descending (legacy behaviour)
+        const eventAthletes = meet.athletes
+          .filter(a => a.scores[event] !== undefined)
+          .sort((a, b) => b.scores[event] - a.scores[event]);
+        rows = eventAthletes.map((a, i) => `
+          <tr>
+            <td>${i + 1}</td>
+            <td>${a.name}</td>
+            <td class="score-cell">${a.scores[event].toFixed(3)}</td>
+          </tr>`).join('');
+      }
 
       return `
         <div class="detail-event-card">

--- a/scripts/parse_pdfs.py
+++ b/scripts/parse_pdfs.py
@@ -181,36 +181,39 @@ def parse_osu_athletes(pages_text):
     """
     Parse OSU athlete scores from NCAA score sheet pages.
     Handles both spaced (one name per line) and compact (concatenated names) formats.
+    Returns (athletes_list, lineups_dict) where lineups_dict maps event -> ordered list
+    of {position, name, score} dicts reflecting competition order.
     """
     athletes = {}
-    
+    lineups = {}  # event -> [(name, score), ...] in competition order (raw, pre-name-fix)
+
     for text in pages_text:
         if "Team: Oregon State" not in text and "Team:Oregon State" not in text:
             continue
-        
+
         lines = text.split("\n")
         current_event = None
         current_scores = []
         collecting_names = False
         names_text = ""
-        
+
         i = 0
         while i < len(lines):
             line = lines[i]
             stripped = line.strip()
-            
+
             # Detect event headers: "V\nT" or "VT" on a line
             next_stripped = lines[i + 1].strip() if i + 1 < len(lines) else ""
-            
+
             def _start_event(event_name, advance):
                 nonlocal current_event, current_scores, collecting_names, names_text
-                _flush_event(athletes, current_event, current_scores, names_text)
+                _flush_event(athletes, lineups, current_event, current_scores, names_text)
                 current_event = event_name
                 current_scores = []
                 collecting_names = False
                 names_text = ""
                 return advance
-            
+
             if (stripped == "V" and next_stripped == "T") or stripped == "VT":
                 skip = _start_event("vault", 2 if stripped == "V" else 1)
                 i += skip; continue
@@ -226,11 +229,11 @@ def parse_osu_athletes(pages_text):
             elif (stripped == "F" and next_stripped == "X") or stripped == "FX":
                 skip = _start_event("floor", 2 if stripped == "F" else 1)
                 i += skip; continue
-            
+
             if current_event is None:
                 i += 1
                 continue
-            
+
             # Score lines: individual "1 9.95 9.85 9.95 9.90 9.875" OR
             # compact "#Name SV1 J1...1 9.959.75... 9.7502 10.00..."
             if not collecting_names:
@@ -245,28 +248,28 @@ def parse_osu_athletes(pages_text):
                         nums = re.findall(r"[\d]+\.[\d]+", stripped)
                         if nums:
                             current_scores.append(float(nums[-1]))
-            
+
             # Event total triggers name collection
             if re.match(r"(VT|UB|BB|FX)\s+Score:", stripped):
                 collecting_names = True
                 names_text = ""
                 i += 1
                 continue
-            
+
             # Collecting names until we hit # or Judge or empty or next event
             if collecting_names:
                 if stripped.startswith("#") or "Judge" in stripped or stripped == "\xa0" or stripped == "":
-                    _flush_event(athletes, current_event, current_scores, names_text)
+                    _flush_event(athletes, lineups, current_event, current_scores, names_text)
                     collecting_names = False
                     names_text = ""
                 elif re.search(r"[A-Za-z]", stripped) and "Score" not in stripped and "©" not in stripped and "Running" not in stripped:
                     names_text += stripped
-            
+
             i += 1
-        
+
         # Flush last event
-        _flush_event(athletes, current_event, current_scores, names_text)
-        
+        _flush_event(athletes, lineups, current_event, current_scores, names_text)
+
         # Parse AA from Final Score section
         final_idx = text.find("Final Score:")
         if final_idx >= 0:
@@ -288,20 +291,25 @@ def parse_osu_athletes(pages_text):
                                 athletes[name]["scores"]["aa"] = aa_scores[4]
                             break
                     break
-    
-    return fix_name_splits(list(athletes.values()))
+
+    fixed_athletes = fix_name_splits(list(athletes.values()))
+    fixed_lineups = fix_lineup_names(lineups)
+    return fixed_athletes, fixed_lineups
 
 
-def _flush_event(athletes, event, scores, names_text):
-    """Assign scores to athletes for a given event."""
+def _flush_event(athletes, lineups, event, scores, names_text):
+    """Assign scores to athletes for a given event and record competition-order lineup."""
     if not event or not scores or not names_text:
         return
     names = split_concatenated_names(names_text)
+    if event not in lineups:
+        lineups[event] = []
     for j, name in enumerate(names):
         if j < len(scores):
             if name not in athletes:
                 athletes[name] = {"name": name, "team": "Oregon State", "scores": {}}
             athletes[name]["scores"][event] = scores[j]
+            lineups[event].append({"position": j + 1, "name": name, "score": scores[j]})
 
 
 def fix_name_splits(athletes):
@@ -345,6 +353,25 @@ def fix_name_splits(athletes):
             }
 
     return list(merged.values())
+
+
+def fix_lineup_names(lineups):
+    """
+    Apply the same name-fix logic used in fix_name_splits to the lineup dicts.
+    Ensures lineup athlete names match the corrected athlete names.
+    """
+    fixed = {}
+    for event, entries in lineups.items():
+        fixed_entries = []
+        for entry in entries:
+            name = entry["name"]
+            if name == "Taylor De":
+                name = "Taylor DeVries"
+            elif name.startswith("Vries") and len(name) > 5:
+                name = name[5:].strip()
+            fixed_entries.append({"position": entry["position"], "name": name, "score": entry["score"]})
+        fixed[event] = fixed_entries
+    return fixed
 
 
 def parse_meet_pdf(meet_info):
@@ -394,8 +421,8 @@ def parse_meet_pdf(meet_info):
     osu = team_scores[osu_key]
     is_quad = meet_info.get("isQuad", False)
     
-    athletes = parse_osu_athletes(score_sheet_pages)
-    
+    athletes, lineups = parse_osu_athletes(score_sheet_pages)
+
     attendance = meet_info.get("attendance", "")
     if not attendance:
         for t in all_text:
@@ -447,6 +474,7 @@ def parse_meet_pdf(meet_info):
                     "floor": {"osu": osu["floor"], "opponent": opp_data["floor"]},
                 },
                 "athletes": athletes,
+                "lineups": lineups,
                 "allTeams": all_teams,
             }
             if attendance:
@@ -475,6 +503,7 @@ def parse_meet_pdf(meet_info):
                 "floor": {"osu": osu["floor"], "opponent": opp_events["floor"]},
             },
             "athletes": athletes,
+            "lineups": lineups,
         }
         if attendance:
             meet_data["attendance"] = attendance


### PR DESCRIPTION
Addresses issue #14

## Changes

### `scripts/parse_pdfs.py`
- `_flush_event` now accepts a `lineups` dict and records each athlete entry as `{position, name, score}` in the order they appear in the PDF (i.e. competition order)
- Added `fix_lineup_names()` to apply the same Taylor DeVries / Vries-prefix name-fix to lineup entries, keeping names consistent with the `athletes` array
- `parse_osu_athletes` returns `(athletes_list, lineups_dict)` — callers updated accordingly
- Both single-meet and quad-meet records now include a `lineups` field
- `data/meets.json` regenerated with lineups for all parseable meets (hardcoded image-based meets like Alabama don't have lineups)

### `public/js/app.js`
- `showMeetDetail` renders each event lineup from `meet.lineups[event]` when available, preserving competition order (position 1 first)
- Position number shown as a subtle muted monospace prefix on each row
- Top score in the lineup gets the orange highlight via `.score-top` class
- Falls back gracefully to score-sorted view for meets without lineup data

### `public/css/style.css`
- Added `.lineup-table .score-cell.score-top` rule for orange highlight on highest score

## Acceptance Criteria
- [x] `meets.json` contains a `lineups` object per meet with vault/bars/beam/floor arrays
- [x] Each lineup array is in competition order (position 1 first)
- [x] Meet detail page renders athletes in competition order for each event
- [x] Position number shown as subtle prefix on each row
- [x] Highest score in each lineup is highlighted orange