### PR TITLE
feat: add clickable names/meets and home/away H/A badges

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -353,20 +353,20 @@ main {
 
 .badge-home {
   background: #D73F09;
-  color: white;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
-  margin-left: 0.5rem;
-  border-radius: 4px;
+  color: #fff;
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 700;
 }
 
 .badge-away {
   background: #3a3a3a;
   color: #aaa;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
-  margin-left: 0.5rem;
-  border-radius: 4px;
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 700;
 }
 
 .badge-home-short {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -18,6 +18,13 @@
     vault: 'VT', bars: 'UB', beam: 'BB', floor: 'FX', aa: 'AA'
   };
 
+  // ===== Home/Away Badge =====
+  function homeAwayBadge(isHome) {
+    return isHome
+      ? '<span class="badge-home">H</span>'
+      : '<span class="badge-away">A</span>';
+  }
+
   // ===== Utility =====
   function formatDate(dateStr) {
     const d = new Date(dateStr + 'T12:00:00');
@@ -389,7 +396,7 @@
       <div class="meet-card${m.status === 'in_progress' ? ' meet-card-live' : ''}" data-meet-id="${m.id}">
         <div class="meet-header">
           <div>
-            <div class="meet-opponent">${m.opponent}${m.isHome ? '<span class="badge badge-home">HOME</span>' : ''} ${statusBadge}</div>
+            <div class="meet-opponent"><span class="inline-link" style="cursor:pointer">${m.opponent}</span> ${homeAwayBadge(m.isHome)} ${statusBadge}</div>
             <div class="meet-date">${formatDateLong(m.date)}</div>
             <div class="meet-location">${m.location}</div>
           </div>
@@ -505,7 +512,7 @@
       const rows = eventAthletes.map((a, i) => `
         <tr>
           <td>${i + 1}</td>
-          <td>${a.name}</td>
+          <td><a class="inline-link" style="cursor:pointer" onclick="showGymnastProfile('${a.name.replace(/'/g, "\\'")}')">${a.name}</a></td>
           <td class="score-cell">${a.scores[event].toFixed(3)}</td>
         </tr>`).join('');
 
@@ -539,7 +546,7 @@
       <div class="detail-hero">
         <div class="meet-header">
           <div>
-            <div class="meet-opponent" style="font-size:1.5rem;">vs ${meet.opponent}</div>
+            <div class="meet-opponent" style="font-size:1.5rem;">vs ${meet.opponent} ${homeAwayBadge(meet.isHome)}</div>
             <div class="meet-date">${formatDateLong(meet.date)}</div>
             <div class="meet-location">${meet.location}${meet.attendance ? ` • Attendance: ${meet.attendance}` : ''}</div>
           </div>
@@ -679,7 +686,12 @@
         return `<td class="${isBest ? 'personal-best' : ''}">${m.scores[e].toFixed(3)}${isBest ? ' ★' : ''}</td>`;
       }).join('');
       const aa = m.scores.aa ? `<td>${m.scores.aa.toFixed(3)}</td>` : '<td style="color:var(--text-muted)">—</td>';
-      return `<tr><td>${formatDate(m.date)}</td><td>${m.opponent}</td>${cells}${aa}</tr>`;
+      const meetObj = meets.find(mt => mt.id === m.meetId);
+      const badge = meetObj ? homeAwayBadge(meetObj.isHome) : '';
+      const oppLink = m.meetId
+        ? `<a class="inline-link" style="cursor:pointer" onclick="showMeetDetail('${m.meetId}')">${m.opponent}</a> ${badge}`
+        : `${m.opponent} ${badge}`;
+      return `<tr><td>${formatDate(m.date)}</td><td>${oppLink}</td>${cells}${aa}</tr>`;
     }).join('');
 
     detail.innerHTML = `
@@ -761,15 +773,19 @@
       return;
     }
 
-    list.innerHTML = top.map((s, i) => `
+    list.innerHTML = top.map((s, i) => {
+      const meet = meets.find(m => m.id === s.meetId);
+      const badge = meet ? homeAwayBadge(meet.isHome) : '';
+      return `
       <div class="leaderboard-item">
         <div class="lb-rank ${i < 3 ? 'top-3' : ''}">${i + 1}</div>
         <div class="lb-info">
-          <div class="lb-name">${s.name}</div>
-          <div class="lb-context">${formatDate(s.meetDate)} vs ${s.opponent}</div>
+          <div class="lb-name"><a class="inline-link" style="cursor:pointer" onclick="showGymnastProfile('${s.name.replace(/'/g, "\\'")}')">${s.name}</a></div>
+          <div class="lb-context">${formatDate(s.meetDate)} vs <a class="inline-link" style="cursor:pointer" onclick="showMeetDetail('${s.meetId}')">${s.opponent}</a> ${badge}</div>
         </div>
         <div class="lb-score">${s.score.toFixed(3)}</div>
-      </div>`).join('');
+      </div>`;
+    }).join('');
   }
 
   // ===== Event Listeners =====


### PR DESCRIPTION
Addresses issue #26

## Changes

### public/js/app.js
- Added `homeAwayBadge(isHome)` helper returning compact H/A badge spans
- **Meet cards**: opponent name styled as inline-link (card click already navigates), HOME badge replaced with H/A badge
- **Meet detail lineup**: athlete names wrapped in `<a class="inline-link">` calling `showGymnastProfile(name)` on click
- **Meet detail header**: H/A badge added next to opponent name
- **Gymnast profile meet history**: opponent names wrapped in `<a class="inline-link">` calling `showMeetDetail(meetId)`, H/A badge added
- **Leaderboard rows**: gymnast name and meet opponent both clickable, H/A badge added after opponent name

### public/css/style.css
- Updated `.badge-home` and `.badge-away` to compact spec (0.7rem, 1px 5px padding, font-weight 700)

All changes verified syntax-clean via `node -e "new Function(...)"" before commit.