### PR TITLE
feat: implement backend stats API layer (team, event & individual analytics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 data/pdfs/
 data/pdf_cache/
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # OSU Gymnastics 2026
+
+## Stats API
+
+All stats are pre-computed server-side when data loads and cached in memory. Stats are recomputed on data refresh.
+
+### Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/stats` | Full stats bundle (team, events, athletes, leaderboards, heatmap, competitors) |
+| `GET /api/stats/summary` | Lightweight summary: record, team avg, season high, last meet |
+| `GET /api/stats/team` | Team-level stats: W-L record, season avg/high/low, home/away, NQS, hot/cold athletes, trajectory |
+| `GET /api/stats/athletes` | All athlete stats keyed by name |
+| `GET /api/stats/athletes/:name` | Single athlete stats (URL-encode the name, e.g. `/api/stats/athletes/Taylor%20DeVries`) |
+| `GET /api/stats/events/:event` | Single event stats: `vault`, `bars`, `beam`, or `floor` |
+
+### Stats Bundle Schema
+
+```json
+{
+  "team": {
+    "record": { "wins": 7, "losses": 10 },
+    "dayRecord": { "wins": 5, "losses": 8 },
+    "seasonAvg": 196.066,
+    "seasonHigh": 197.250,
+    "seasonLow": 194.675,
+    "homeAvg": 196.690,
+    "awayAvg": 195.546,
+    "trajectory": 0.123,
+    "nqs": 196.690,
+    "nqsDetail": { "nqs": 196.690, "scoresUsed": [...], "dropped": 196.35 },
+    "hotCold": { "hot": [...], "cold": [...] },
+    "scoreTrend": [{ "date": "...", "score": 196.5, "isHome": true, "opponent": "..." }]
+  },
+  "eventTrends": {
+    "vault": { "seasonAvg": 9.739, "recentAvg": 9.806, "trendDirection": "up", "rotationRecord": { "wins": 7, "losses": 10 } }
+  },
+  "events": {
+    "vault": {
+      "seasonAvg": 48.925, "best": 49.3, "worst": 48.5, "stdDev": 0.25,
+      "topScores": [{ "name": "...", "score": 9.9, "date": "...", "opponent": "..." }],
+      "lineupPositionAvgs": { "1": { "avg": 9.72, "best": 9.85, "count": 11 }, ... }
+    }
+  },
+  "athletes": {
+    "Athlete Name": {
+      "name": "...", "totalAppearances": 22,
+      "bio": { "classYear": "Freshman", "position": "All-Around" },
+      "events": {
+        "vault": { "avg": 9.78, "best": 9.9, "stdDev": 0.05, "trendSlope": 0.003, "homeDelta": 0.02, "clutchAvg": 9.8 }
+      }
+    }
+  },
+  "leaderboards": { "vault": [{ "name": "...", "avg": 9.8, "best": 9.9, "appearances": 10 }] },
+  "heatmap": { "teamAvgs": { "vault": 9.73 }, "gymnasts": [{ "name": "...", "overallAvg": 9.75, "evAvgs": {...}, "evDelta": {...} }] },
+  "competitors": { "UCLA": { "meetsPlayed": 1, "eventAvgs": {...}, "topScorers": {...} } },
+  "summary": { "record": "7-10", "teamAvg": 196.066, "seasonHigh": 197.250, "meetsPlayed": 11, "lastMeetDate": "2026-03-14" },
+  "computedAt": "2026-03-29T06:35:43.486Z"
+}
+```
+
+### Stats Module
+
+The stats computation lives in `stats/stats.js` — a pure Node.js module with no Express dependency. Can be run standalone:
+
+```bash
+node stats/stats.js  # Prints summary to console
+```

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,6 +12,7 @@
   let lastRefreshedTime = null;
   let autoRefreshInterval = null;
   let autoRefreshEnabled = false;
+  let statsCache = {};
 
   const EVENT_NAMES = {
     vault: 'Vault', bars: 'Bars', beam: 'Beam', floor: 'Floor', aa: 'All-Around'
@@ -106,10 +107,11 @@
       const data = await res.json();
 
       if (data.success) {
-        // Re-fetch the meets data
-        const meetsRes = await fetch('/api/meets');
+        // Re-fetch the meets data and stats
+        const [meetsRes2, statsRes2] = await Promise.all([fetch('/api/meets'), fetch('/api/stats')]);
         const oldMeets = meets.slice();
-        meets = await meetsRes.json();
+        meets = await meetsRes2.json();
+        try { if (statsRes2.ok) statsCache = await statsRes2.json(); } catch (e) { /* keep old cache */ }
 
         lastRefreshedTime = new Date();
         updateLastUpdatedDisplay();
@@ -192,6 +194,17 @@
       photos = await photosRes.json();
       bios = await biosRes.json();
       meetPhotos = await meetPhotosRes.json();
+
+      // Fetch pre-computed stats from backend (non-blocking — fallback to inline if it fails)
+      try {
+        const statsRes = await fetch('/api/stats');
+        if (statsRes.ok) {
+          statsCache = await statsRes.json();
+        }
+      } catch (e) {
+        console.warn('[OSU] Stats API unavailable, using inline computation fallback');
+        statsCache = {};
+      }
 
       // Set initial lastRefreshed from meet data
       const refreshed = meets.find(m => m.lastRefreshed);
@@ -301,7 +314,11 @@
     const mc = document.getElementById('missionControl');
     if (!mc) return;
 
-    // Unique competition days
+    // Use pre-computed stats from API when available
+    const ts = statsCache.team || null;
+    const et = statsCache.eventTrends || null;
+
+    // Unique competition days (fallback computation)
     const compDays = [];
     const seenD = new Set();
     meets.slice().sort((a,b)=>new Date(a.date)-new Date(b.date)).forEach(m => {
@@ -312,40 +329,37 @@
         elevFt: m.elevationFt ?? null });
     });
 
-    const scoredMeets = meets.filter(m => m.result === 'W' || m.result === 'L');
-    const wins = meets.filter(m => m.result === 'W').length;
-    const losses = meets.filter(m => m.result === 'L').length;
-
-    // Unique day wins
-    const dayWins = new Set(), dayLosses = new Set();
-    meets.forEach(m => {
-      if (m.result === 'W') dayWins.add(m.date);
-      else if (m.result === 'L') dayLosses.add(m.date);
-    });
+    const wins = ts ? ts.record.wins : meets.filter(m => m.result === 'W').length;
+    const losses = ts ? ts.record.losses : meets.filter(m => m.result === 'L').length;
 
     const allScores = compDays.map(d=>d.total);
     const homeScores = compDays.filter(d=>d.isHome).map(d=>d.total);
     const awayScores = compDays.filter(d=>!d.isHome).map(d=>d.total);
-    const teamAvg = mcMean(allScores);
-    const homeAvg = mcMean(homeScores);
-    const awayAvg = mcMean(awayScores);
-    const seasonHigh = allScores.length ? Math.max(...allScores) : null;
+    const teamAvg = ts ? ts.seasonAvg : mcMean(allScores);
+    const homeAvg = ts ? ts.homeAvg : mcMean(homeScores);
+    const awayAvg = ts ? ts.awayAvg : mcMean(awayScores);
+    const seasonHigh = ts ? ts.seasonHigh : (allScores.length ? Math.max(...allScores) : null);
     const homeDiff = homeAvg && teamAvg ? homeAvg - teamAvg : null;
 
-    // Season trajectory — first half vs second half
-    const half = Math.floor(allScores.length / 2);
-    const firstHalf = mcMean(allScores.slice(0, half));
-    const secondHalf = mcMean(allScores.slice(half));
-    const trajectory = firstHalf && secondHalf ? secondHalf - firstHalf : null;
+    // Season trajectory
+    const trajectory = ts ? ts.trajectory : (() => {
+      const half = Math.floor(allScores.length / 2);
+      const f = mcMean(allScores.slice(0, half));
+      const s = mcMean(allScores.slice(half));
+      return f && s ? s - f : null;
+    })();
     const trajArrow = trajectory == null ? '' : trajectory > 0.1 ? '🚀' : trajectory < -0.1 ? '📉' : '→';
     const trajLabel = trajectory == null ? '' : trajectory > 0.1 ? `Up ${trajectory.toFixed(3)} pts vs early season` : trajectory < -0.1 ? `Down ${Math.abs(trajectory).toFixed(3)} pts vs early season` : 'Flat season trend';
 
-    // Event trends — compare first 5 vs last 5 scored meets
+    // NQS from stats API
+    const nqs = ts ? ts.nqs : null;
+
+    // Event trends
     const EVS = ['vault','bars','beam','floor'];
     const EVlabel = {vault:'VAULT',bars:'BARS',beam:'BEAM',floor:'FLOOR'};
     const EVemoji = {vault:'🤸',bars:'💪',beam:'⚖️',floor:'🔥'};
 
-    function eventTrend(ev) {
+    function eventTrendFallback(ev) {
       const dates = [...seenD].slice().sort();
       const pts = [];
       dates.forEach(date => {
@@ -362,48 +376,59 @@
     }
 
     const evData = {};
-    EVS.forEach(ev => { evData[ev] = eventTrend(ev); });
+    EVS.forEach(ev => {
+      if (et && et[ev]) {
+        evData[ev] = { avg: et[ev].seasonAvg, trend: et[ev].trendDiff || 0, recent: et[ev].recentAvg };
+      } else {
+        evData[ev] = eventTrendFallback(ev);
+      }
+    });
 
-    // Hot/Cold gymnasts — last 3 meets vs season avg
-    function gymnLastN(name, n) {
-      const scored = [];
-      const dates = new Set();
-      meets.slice().sort((a,b)=>new Date(b.date)-new Date(a.date)).forEach(m => {
-        if (dates.size >= n || dates.has(m.date)) return;
-        const a = m.athletes.find(x=>x.name===name&&x.team==='Oregon State');
-        if (!a) return;
-        const evScores = EVS.map(ev=>a.scores[ev]).filter(s=>s!==undefined&&s>0);
-        if (!evScores.length) return;
-        dates.add(m.date);
-        evScores.forEach(s=>scored.push(s));
-      });
-      return mcMean(scored);
+    // Hot/Cold gymnasts from stats API
+    let hot, cold;
+    if (ts && ts.hotCold) {
+      hot = ts.hotCold.hot || [];
+      cold = ts.hotCold.cold || [];
+    } else {
+      // Fallback to inline computation
+      function gymnLastN(name, n) {
+        const scored = [];
+        const dates = new Set();
+        meets.slice().sort((a,b)=>new Date(b.date)-new Date(a.date)).forEach(m => {
+          if (dates.size >= n || dates.has(m.date)) return;
+          const a = m.athletes.find(x=>x.name===name&&x.team==='Oregon State');
+          if (!a) return;
+          const evScores = EVS.map(ev=>a.scores[ev]).filter(s=>s!==undefined&&s>0);
+          if (!evScores.length) return;
+          dates.add(m.date);
+          evScores.forEach(s=>scored.push(s));
+        });
+        return mcMean(scored);
+      }
+      function gymnSeasonAvg(name) {
+        const scores = [];
+        const seen = new Set();
+        meets.forEach(m => {
+          if (seen.has(m.date)) return;
+          const a = m.athletes.find(x=>x.name===name&&x.team==='Oregon State');
+          if (!a) return;
+          const evScores = EVS.map(ev=>a.scores[ev]).filter(s=>s!==undefined&&s>0);
+          if (!evScores.length) return;
+          seen.add(m.date);
+          evScores.forEach(s=>scores.push(s));
+        });
+        return mcMean(scores);
+      }
+      const gymnasts = [...new Set(meets.flatMap(m=>m.athletes.filter(a=>a.team==='Oregon State').map(a=>a.name)))];
+      const gymnForm = gymnasts.map(name => {
+        const recent = gymnLastN(name, 3);
+        const season = gymnSeasonAvg(name);
+        if (!recent || !season) return null;
+        return { name, recent, season, diff: recent - season };
+      }).filter(Boolean).sort((a,b)=>b.diff-a.diff);
+      hot = gymnForm.slice(0,3).filter(g=>g.diff>0.01);
+      cold = gymnForm.slice(-3).filter(g=>g.diff<-0.01).reverse();
     }
-    function gymnSeasonAvg(name) {
-      const scores = [];
-      const seen = new Set();
-      meets.forEach(m => {
-        if (seen.has(m.date)) return;
-        const a = m.athletes.find(x=>x.name===name&&x.team==='Oregon State');
-        if (!a) return;
-        const evScores = EVS.map(ev=>a.scores[ev]).filter(s=>s!==undefined&&s>0);
-        if (!evScores.length) return;
-        seen.add(m.date);
-        evScores.forEach(s=>scores.push(s));
-      });
-      return mcMean(scores);
-    }
-
-    const gymnasts = [...new Set(meets.flatMap(m=>m.athletes.filter(a=>a.team==='Oregon State').map(a=>a.name)))];
-    const gymnForm = gymnasts.map(name => {
-      const recent = gymnLastN(name, 3);
-      const season = gymnSeasonAvg(name);
-      if (!recent || !season) return null;
-      return { name, recent, season, diff: recent - season };
-    }).filter(Boolean).sort((a,b)=>b.diff-a.diff);
-
-    const hot = gymnForm.slice(0,3).filter(g=>g.diff>0.01);
-    const cold = gymnForm.slice(-3).filter(g=>g.diff<-0.01).reverse();
 
     // Record context
     const need500 = Math.max(0, losses - wins);
@@ -445,6 +470,11 @@
           <div class="mc-stat-label">Season High 🏆</div>
           <div class="mc-context">${compDays.find(d=>d.total===seasonHigh)?.date || ''}</div>
         </div>
+        ${nqs ? `<div class="mc-stat-card">
+          <div class="mc-stat-value" id="mcNqs">0.000</div>
+          <div class="mc-stat-label">NQS 📊</div>
+          <div class="mc-context">Nat'l Qualifying Score</div>
+        </div>` : ''}
       </div>
 
       <div class="mc-event-row">
@@ -495,6 +525,7 @@
       if (homeAvg) animateValue(document.getElementById('mcHome'), 196, homeAvg, 900, 3);
       if (awayAvg) animateValue(document.getElementById('mcAway'), 196, awayAvg, 900, 3);
       if (seasonHigh) animateValue(document.getElementById('mcHigh'), 196, seasonHigh, 1000, 3);
+      if (nqs) animateValue(document.getElementById('mcNqs'), 196, nqs, 1000, 3);
     }, 100);
   }
 
@@ -697,38 +728,45 @@
     const EVS = ['vault','bars','beam','floor'];
     const EVlabel = {vault:'VAULT',bars:'BARS',beam:'BEAM',floor:'FLOOR'};
 
-    // Per-gymnast, per-event averages
-    const gymnData = {};
-    const seen = new Set();
-    meets.forEach(m => {
-      m.athletes.filter(a=>a.team==='Oregon State').forEach(a => {
-        if (!gymnData[a.name]) gymnData[a.name] = {vault:[],bars:[],beam:[],floor:[]};
-        EVS.forEach(ev => {
-          const s = a.scores[ev];
-          if (s !== undefined && s > 0) {
-            // Dedup per date
-            const key = `${a.name}|${ev}|${m.date}`;
-            if (!seen.has(key)) { seen.add(key); gymnData[a.name][ev].push(s); }
-          }
+    let teamAvgs, gymnList;
+
+    if (statsCache.heatmap) {
+      // Use pre-computed heatmap from stats API
+      teamAvgs = statsCache.heatmap.teamAvgs;
+      gymnList = statsCache.heatmap.gymnasts.map(g => ({
+        name: g.name,
+        overallAvg: g.overallAvg,
+        evAvgs: g.evAvgs,
+      }));
+    } else {
+      // Fallback: compute inline
+      const gymnData = {};
+      const seen = new Set();
+      meets.forEach(m => {
+        m.athletes.filter(a=>a.team==='Oregon State').forEach(a => {
+          if (!gymnData[a.name]) gymnData[a.name] = {vault:[],bars:[],beam:[],floor:[]};
+          EVS.forEach(ev => {
+            const s = a.scores[ev];
+            if (s !== undefined && s > 0) {
+              const key = `${a.name}|${ev}|${m.date}`;
+              if (!seen.has(key)) { seen.add(key); gymnData[a.name][ev].push(s); }
+            }
+          });
         });
       });
-    });
-
-    // Team averages per event
-    const teamAvgs = {};
-    EVS.forEach(ev => {
-      const all = Object.values(gymnData).flatMap(g=>g[ev]);
-      teamAvgs[ev] = mcMean(all);
-    });
-
-    // Sort gymnasts by overall avg
-    const gymnList = Object.entries(gymnData).map(([name, evData]) => {
-      const allScores = EVS.flatMap(ev=>evData[ev]);
-      const overallAvg = mcMean(allScores);
-      const evAvgs = {};
-      EVS.forEach(ev => { evAvgs[ev] = mcMean(evData[ev]); });
-      return { name, overallAvg, evAvgs };
-    }).filter(g=>g.overallAvg).sort((a,b)=>b.overallAvg-a.overallAvg);
+      teamAvgs = {};
+      EVS.forEach(ev => {
+        const all = Object.values(gymnData).flatMap(g=>g[ev]);
+        teamAvgs[ev] = mcMean(all);
+      });
+      gymnList = Object.entries(gymnData).map(([name, evData]) => {
+        const allScores = EVS.flatMap(ev=>evData[ev]);
+        const overallAvg = mcMean(allScores);
+        const evAvgs = {};
+        EVS.forEach(ev => { evAvgs[ev] = mcMean(evData[ev]); });
+        return { name, overallAvg, evAvgs };
+      }).filter(g=>g.overallAvg).sort((a,b)=>b.overallAvg-a.overallAvg);
+    }
 
     function heatColor(val, teamAvg) {
       if (!val || !teamAvg) return '#1e1e1e';
@@ -1786,6 +1824,41 @@
       ${(()=>{try{return renderMeetWildStats(meet);}catch(e){return '<div style="color:red;padding:1rem;background:#1a0000;border-radius:8px;margin-bottom:1rem">⚠️ Wild Stats error: '+e.message+'</div>';}})()}
       <h2 class="section-title" style="margin-bottom:1rem;">Event Breakdown</h2>
       <div class="detail-event-grid">${eventCards}</div>
+      ${(() => {
+        // Competitor roster section from stats API
+        const ca = meet.competitorAthletes;
+        if (!ca || typeof ca !== 'object' || Object.keys(ca).length === 0) return '';
+        const compStats = statsCache.competitors || {};
+        let html = '<div class="section-card" style="margin-top:1rem;"><h2 class="section-title">🏅 Competitor Rosters</h2>';
+        html += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem;">';
+        Object.entries(ca).forEach(([team, athletes]) => {
+          if (!athletes || typeof athletes !== 'object') return;
+          const seasonData = compStats[team];
+          html += '<div style="background:var(--card);border:1px solid #333;border-radius:8px;padding:0.75rem;">';
+          html += '<div style="font-family:Oswald;color:#fff;font-size:1rem;margin-bottom:0.5rem;">' + team;
+          if (seasonData) html += ' <span style="color:#888;font-size:0.7rem;">(' + seasonData.meetsPlayed + ' meets this season)</span>';
+          html += '</div>';
+          const entries = Object.entries(athletes);
+          const sorted = entries.map(([name, scores]) => {
+            const allScores = typeof scores === 'object' ? Object.values(scores).filter(s => typeof s === 'number' && s > 0) : [];
+            const best = allScores.length ? Math.max(...allScores) : 0;
+            return { name, scores, best };
+          }).sort((a, b) => b.best - a.best).slice(0, 8);
+          sorted.forEach(({ name, scores }) => {
+            if (typeof scores !== 'object') return;
+            const evs = Object.entries(scores).filter(([,s]) => typeof s === 'number' && s > 0);
+            if (!evs.length) return;
+            html += '<div style="display:flex;justify-content:space-between;padding:0.2rem 0;font-size:0.78rem;border-bottom:1px solid #222;">';
+            html += '<span style="color:#ccc;">' + name + '</span>';
+            html += '<span style="color:#888;">' + evs.map(([ev, s]) => EVENT_SHORT[ev] + ':' + s.toFixed(3)).join(' ') + '</span>';
+            html += '</div>';
+          });
+          if (entries.length > 8) html += '<div style="color:#666;font-size:0.7rem;margin-top:0.25rem;">+ ' + (entries.length - 8) + ' more</div>';
+          html += '</div>';
+        });
+        html += '</div></div>';
+        return html;
+      })()}
     `;
 
     // Bind auto-refresh toggle
@@ -2486,17 +2559,6 @@
     const EVS = ['vault','bars','beam','floor'];
     const EV_LBL = {vault:'Vault',bars:'Bars',beam:'Beam',floor:'Floor'};
     function gmean(arr) { return arr.length ? arr.reduce((s,v)=>s+v,0)/arr.length : 0; }
-    function gsd(arr) {
-      if (arr.length < 2) return null;
-      const m = gmean(arr);
-      return Math.sqrt(arr.reduce((s,v)=>s+Math.pow(v-m,2),0)/(arr.length-1));
-    }
-    function glinReg(pts) {
-      const n=pts.length; if(n<2) return {slope:0};
-      const sx=pts.reduce((s,p)=>s+p.x,0), sy=pts.reduce((s,p)=>s+p.y,0);
-      const sxy=pts.reduce((s,p)=>s+p.x*p.y,0), sx2=pts.reduce((s,p)=>s+p.x*p.x,0);
-      return {slope:(n*sxy-sx*sy)/(n*sx2-sx*sx)||0};
-    }
     function gfmt(n) { return typeof n==='number'&&!isNaN(n)?n.toFixed(3):'—'; }
     function gdiff(n) { if(typeof n!=='number'||isNaN(n)) return '—'; return (n>=0?'+':'')+n.toFixed(3); }
     function arrow(s) {
@@ -2506,49 +2568,83 @@
       return '<span style="color:#aaa">►</span>';
     }
 
-    const sm = meets.slice().sort((a,b)=>new Date(a.date)-new Date(b.date));
-    const t0 = new Date(sm[0].date+'T12:00:00');
+    let evStats;
 
-    function evEntries(ev) {
-      const out=[], seen=new Set();
-      sm.forEach(meet => {
-        if(seen.has(meet.date)) return;
-        const a=meet.athletes.find(x=>x.name===name);
-        if(a&&a.scores[ev]!==undefined){
-          seen.add(meet.date);
-          out.push({
-            score:a.scores[ev], date:meet.date, isHome:meet.isHome,
-            result:meet.result, gap:Math.abs((meet.osuScore||0)-(meet.opponentScore||0)),
-            day:Math.round((new Date(meet.date+'T12:00:00')-t0)/864e5)
-          });
-        }
-      });
-      return out;
+    if (statsCache.athletes && statsCache.athletes[name]) {
+      // Use pre-computed athlete stats from API
+      const ath = statsCache.athletes[name];
+      evStats = EVS.map(ev => {
+        const e = ath.events[ev];
+        if (!e || e.appearances < 2) return null;
+        return {
+          ev, n: e.appearances, avg: e.avg, best: e.best, sd: e.stdDev, slope: e.trendSlope,
+          homeAvg: e.homeAvg, awayAvg: e.awayAvg,
+          haDiff: e.homeDelta,
+          winAvg: e.winAvg, lossAvg: e.lossAvg,
+          wlDiff: e.winLossDelta,
+          clutch: e.clutchAvg,
+          janAvg: e.janAvg, lateAvg: e.lateAvg,
+          seasonDiff: e.seasonDelta
+        };
+      }).filter(Boolean);
+    } else {
+      // Fallback: compute inline
+      function gsd(arr) {
+        if (arr.length < 2) return null;
+        const m = gmean(arr);
+        return Math.sqrt(arr.reduce((s,v)=>s+Math.pow(v-m,2),0)/(arr.length-1));
+      }
+      function glinReg(pts) {
+        const n=pts.length; if(n<2) return {slope:0};
+        const sx=pts.reduce((s,p)=>s+p.x,0), sy=pts.reduce((s,p)=>s+p.y,0);
+        const sxy=pts.reduce((s,p)=>s+p.x*p.y,0), sx2=pts.reduce((s,p)=>s+p.x*p.x,0);
+        return {slope:(n*sxy-sx*sy)/(n*sx2-sx*sx)||0};
+      }
+
+      const sm = meets.slice().sort((a,b)=>new Date(a.date)-new Date(b.date));
+      const t0 = new Date(sm[0].date+'T12:00:00');
+
+      function evEntries(ev) {
+        const out=[], seen=new Set();
+        sm.forEach(meet => {
+          if(seen.has(meet.date)) return;
+          const a=meet.athletes.find(x=>x.name===name);
+          if(a&&a.scores[ev]!==undefined){
+            seen.add(meet.date);
+            out.push({
+              score:a.scores[ev], date:meet.date, isHome:meet.isHome,
+              result:meet.result, gap:Math.abs((meet.osuScore||0)-(meet.opponentScore||0)),
+              day:Math.round((new Date(meet.date+'T12:00:00')-t0)/864e5)
+            });
+          }
+        });
+        return out;
+      }
+
+      evStats = EVS.map(ev => {
+        const e = evEntries(ev);
+        if(e.length<2) return null;
+        const scores = e.map(x=>x.score);
+        const slope = e.length>=3 ? glinReg(e.map(x=>({x:x.day,y:x.score}))).slope*7 : null;
+        const home=e.filter(x=>x.isHome).map(x=>x.score);
+        const away=e.filter(x=>!x.isHome).map(x=>x.score);
+        const wins=e.filter(x=>x.result==='W').map(x=>x.score);
+        const losses=e.filter(x=>x.result==='L').map(x=>x.score);
+        const close=e.filter(x=>x.gap<1.0).map(x=>x.score);
+        const jan=e.filter(x=>new Date(x.date+'T12:00:00').getMonth()===0).map(x=>x.score);
+        const late=e.filter(x=>new Date(x.date+'T12:00:00').getMonth()>0).map(x=>x.score);
+        return {
+          ev, n:e.length, avg:gmean(scores), best:Math.max(...scores), sd:gsd(scores), slope,
+          homeAvg:home.length?gmean(home):null, awayAvg:away.length?gmean(away):null,
+          haDiff:home.length&&away.length?gmean(home)-gmean(away):null,
+          winAvg:wins.length?gmean(wins):null, lossAvg:losses.length?gmean(losses):null,
+          wlDiff:wins.length&&losses.length?gmean(wins)-gmean(losses):null,
+          clutch:close.length?gmean(close):null,
+          janAvg:jan.length?gmean(jan):null, lateAvg:late.length?gmean(late):null,
+          seasonDiff:jan.length&&late.length?gmean(late)-gmean(jan):null
+        };
+      }).filter(Boolean);
     }
-
-    const evStats = EVS.map(ev => {
-      const e = evEntries(ev);
-      if(e.length<2) return null;
-      const scores = e.map(x=>x.score);
-      const slope = e.length>=3 ? glinReg(e.map(x=>({x:x.day,y:x.score}))).slope*7 : null;
-      const home=e.filter(x=>x.isHome).map(x=>x.score);
-      const away=e.filter(x=>!x.isHome).map(x=>x.score);
-      const wins=e.filter(x=>x.result==='W').map(x=>x.score);
-      const losses=e.filter(x=>x.result==='L').map(x=>x.score);
-      const close=e.filter(x=>x.gap<1.0).map(x=>x.score);
-      const jan=e.filter(x=>new Date(x.date+'T12:00:00').getMonth()===0).map(x=>x.score);
-      const late=e.filter(x=>new Date(x.date+'T12:00:00').getMonth()>0).map(x=>x.score);
-      return {
-        ev, n:e.length, avg:gmean(scores), best:Math.max(...scores), sd:gsd(scores), slope,
-        homeAvg:home.length?gmean(home):null, awayAvg:away.length?gmean(away):null,
-        haDiff:home.length&&away.length?gmean(home)-gmean(away):null,
-        winAvg:wins.length?gmean(wins):null, lossAvg:losses.length?gmean(losses):null,
-        wlDiff:wins.length&&losses.length?gmean(wins)-gmean(losses):null,
-        clutch:close.length?gmean(close):null,
-        janAvg:jan.length?gmean(jan):null, lateAvg:late.length?gmean(late):null,
-        seasonDiff:jan.length&&late.length?gmean(late)-gmean(jan):null
-      };
-    }).filter(Boolean);
 
     if(evStats.length===0) return '';
 
@@ -3186,6 +3282,45 @@
 
     const deepDive = buildDeepDive();
 
+    // Lineup position analysis from stats API
+    let lineupPanel = '';
+    const evStatsApi = statsCache.events && statsCache.events[eventKey];
+    if (evStatsApi && evStatsApi.lineupPositionAvgs && Object.keys(evStatsApi.lineupPositionAvgs).length > 0) {
+      const posData = evStatsApi.lineupPositionAvgs;
+      const positions = Object.keys(posData).sort((a, b) => Number(a) - Number(b));
+      const posAvgs = positions.map(p => posData[p].avg);
+      const maxAvg = Math.max(...posAvgs);
+      const minAvg = Math.min(...posAvgs);
+      const anchorPos = positions[positions.length - 1];
+      const anchorAvg = posData[anchorPos]?.avg;
+      const overallAvg = posAvgs.reduce((s, v) => s + v, 0) / posAvgs.length;
+
+      lineupPanel = `
+        <div class="section-card">
+          <h2 class="section-title">📋 Lineup Position Analysis</h2>
+          <p style="color:var(--text-muted);font-size:0.8rem;margin-bottom:1rem;">Average score by lineup position across all meets this season</p>
+          <div style="display:grid;grid-template-columns:repeat(${positions.length},1fr);gap:0.5rem;text-align:center;">
+            ${positions.map(pos => {
+              const p = posData[pos];
+              const isAnchor = pos === anchorPos;
+              const aboveAvg = p.avg > overallAvg;
+              const barPct = ((p.avg - minAvg + 0.01) / (maxAvg - minAvg + 0.02) * 100).toFixed(0);
+              return `<div style="padding:0.5rem;background:var(--card);border-radius:8px;border:1px solid ${isAnchor ? 'var(--orange)' : '#333'}">
+                <div style="font-family:Oswald;font-size:0.7rem;color:#888;margin-bottom:0.25rem;">${isAnchor ? '⚓ ANCHOR' : 'POS ' + pos}</div>
+                <div style="font-family:Oswald;font-size:1.1rem;color:${aboveAvg ? '#2ecc71' : '#e74c3c'}">${p.avg.toFixed(3)}</div>
+                <div style="height:4px;background:#333;border-radius:2px;margin-top:0.4rem;overflow:hidden;">
+                  <div style="height:100%;width:${barPct}%;background:${isAnchor ? 'var(--orange)' : aboveAvg ? '#2ecc71' : '#e74c3c'};border-radius:2px;"></div>
+                </div>
+                <div style="font-size:0.65rem;color:#666;margin-top:0.25rem;">${p.count} scores</div>
+              </div>`;
+            }).join('')}
+          </div>
+          ${anchorAvg && overallAvg ? `<div style="margin-top:0.75rem;font-size:0.8rem;color:var(--text-muted);">
+            Anchor (pos ${anchorPos}) ${anchorAvg > overallAvg ? '<span style="color:#2ecc71">outperforms</span>' : '<span style="color:#e74c3c">underperforms</span>'} average by <strong>${Math.abs(anchorAvg - overallAvg).toFixed(3)}</strong> pts
+          </div>` : ''}
+        </div>`;
+    }
+
     document.getElementById('eventDetailContent').innerHTML = `
       <div class="event-detail-header">
         <div class="event-banner-content">
@@ -3195,6 +3330,7 @@
       </div>
       ${chart}
       ${statsPanel}
+      ${lineupPanel}
       ${gymnastSection}
       ${leaderboard}
       ${breakdown}
@@ -3229,28 +3365,38 @@
   function renderLeaderboard(event) {
     document.querySelectorAll('.event-tab').forEach(t => t.classList.toggle('active', t.dataset.event === event));
 
-    // Group scores by gymnast
-    const byGymnast = {};
-    const sortedMeets = meets.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
-    sortedMeets.forEach(meet => {
-      meet.athletes.forEach(a => {
-        if (a.scores[event] !== undefined) {
-          if (!byGymnast[a.name]) byGymnast[a.name] = [];
-          byGymnast[a.name].push({ score: a.scores[event], meetDate: meet.date, opponent: meet.opponent, meetId: meet.id });
-        }
+    let gymnasts;
+
+    if (statsCache.leaderboards && statsCache.leaderboards[event]) {
+      // Use pre-computed leaderboard from stats API
+      gymnasts = statsCache.leaderboards[event].map(g => ({
+        name: g.name,
+        best: { score: g.best, meetDate: g.bestMeetDate, opponent: g.bestOpponent, meetId: g.bestMeetId },
+        avg: g.avg,
+        recent: g.recent,
+        count: g.appearances,
+      }));
+    } else {
+      // Fallback: compute inline
+      const byGymnast = {};
+      const sortedMeets = meets.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
+      sortedMeets.forEach(meet => {
+        meet.athletes.forEach(a => {
+          if (a.scores[event] !== undefined) {
+            if (!byGymnast[a.name]) byGymnast[a.name] = [];
+            byGymnast[a.name].push({ score: a.scores[event], meetDate: meet.date, opponent: meet.opponent, meetId: meet.id });
+          }
+        });
       });
-    });
-
-    // Build per-gymnast stats
-    const gymnasts = Object.entries(byGymnast).map(([name, entries]) => {
-      const scores = entries.map(e => e.score);
-      const best = entries.reduce((a, b) => a.score > b.score ? a : b);
-      const avg = scores.reduce((s, v) => s + v, 0) / scores.length;
-      const recent = entries[entries.length - 1];
-      return { name, best, avg, recent, count: scores.length };
-    });
-
-    gymnasts.sort((a, b) => b.best.score - a.best.score);
+      gymnasts = Object.entries(byGymnast).map(([name, entries]) => {
+        const scores = entries.map(e => e.score);
+        const best = entries.reduce((a, b) => a.score > b.score ? a : b);
+        const avg = scores.reduce((s, v) => s + v, 0) / scores.length;
+        const recent = entries[entries.length - 1];
+        return { name, best, avg, recent, count: scores.length };
+      });
+      gymnasts.sort((a, b) => b.best.score - a.best.score);
+    }
 
     const list = document.getElementById('leaderboardList');
     if (gymnasts.length === 0) {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');
+const { computeStats } = require('./stats/stats');
 
 const app = express();
 const { execSync } = require('child_process');
@@ -12,8 +13,19 @@ try {
   ASSET_VERSION = execSync('git rev-parse --short HEAD', { cwd: __dirname }).toString().trim();
 } catch (e) {}
 
-// Keep meets data in memory for fast serving
+// Keep meets + bios data in memory for fast serving
 let meetsData = null;
+let biosData = null;
+let statsCache = null;
+
+function loadBiosData() {
+  try {
+    biosData = JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'bios.json'), 'utf-8'));
+  } catch (err) {
+    console.error('Failed to load bios.json:', err.message);
+    biosData = {};
+  }
+}
 
 function loadMeetsData() {
   try {
@@ -24,8 +36,20 @@ function loadMeetsData() {
   }
 }
 
+function recomputeStats() {
+  try {
+    statsCache = computeStats(meetsData || [], biosData || {});
+    console.log(`Stats computed: ${Object.keys(statsCache.athletes).length} athletes, ${Object.keys(statsCache.competitors).length} competitors`);
+  } catch (err) {
+    console.error('Failed to compute stats:', err.message);
+    statsCache = null;
+  }
+}
+
 // Load on startup
+loadBiosData();
 loadMeetsData();
+recomputeStats();
 
 // Serve index.html with injected asset version for automatic cache-busting
 app.get('/', async (req, res) => {
@@ -48,11 +72,12 @@ app.use(express.static('public', {
   }
 }));
 
-app.get('/api/bios', async (req, res) => {
-  try {
-    const raw = await fs.promises.readFile(path.join(__dirname, 'data/bios.json'), 'utf8');
-    res.json(JSON.parse(raw));
-  } catch (e) { res.json({}); }
+app.get('/api/bios', (req, res) => {
+  if (biosData) {
+    res.json(biosData);
+  } else {
+    res.json({});
+  }
 });
 
 app.get('/api/photos', async (req, res) => {
@@ -78,6 +103,66 @@ app.get('/api/meets', (req, res) => {
     res.json(meetsData);
   } else {
     res.sendFile(path.join(__dirname, 'data', 'meets.json'));
+  }
+});
+
+// ── Stats API endpoints ──────────────────────────────────────────────────────
+
+app.get('/api/stats', (req, res) => {
+  if (statsCache) {
+    res.json(statsCache);
+  } else {
+    res.status(503).json({ error: 'Stats not yet computed' });
+  }
+});
+
+app.get('/api/stats/summary', (req, res) => {
+  if (statsCache) {
+    res.json(statsCache.summary);
+  } else {
+    res.status(503).json({ error: 'Stats not yet computed' });
+  }
+});
+
+app.get('/api/stats/team', (req, res) => {
+  if (statsCache) {
+    res.json(statsCache.team);
+  } else {
+    res.status(503).json({ error: 'Stats not yet computed' });
+  }
+});
+
+app.get('/api/stats/athletes', (req, res) => {
+  if (statsCache) {
+    res.json(statsCache.athletes);
+  } else {
+    res.status(503).json({ error: 'Stats not yet computed' });
+  }
+});
+
+app.get('/api/stats/athletes/:name', (req, res) => {
+  if (!statsCache) {
+    return res.status(503).json({ error: 'Stats not yet computed' });
+  }
+  const name = decodeURIComponent(req.params.name);
+  const athlete = statsCache.athletes[name];
+  if (athlete) {
+    res.json(athlete);
+  } else {
+    res.status(404).json({ error: `Athlete "${name}" not found` });
+  }
+});
+
+app.get('/api/stats/events/:event', (req, res) => {
+  if (!statsCache) {
+    return res.status(503).json({ error: 'Stats not yet computed' });
+  }
+  const event = req.params.event;
+  const eventData = statsCache.events[event];
+  if (eventData) {
+    res.json(eventData);
+  } else {
+    res.status(404).json({ error: `Event "${event}" not found. Valid: vault, bars, beam, floor` });
   }
 });
 
@@ -113,8 +198,10 @@ app.post('/api/refresh', async (req, res) => {
       });
     });
 
-    // Reload meets.json into memory
+    // Reload data into memory and recompute stats
     loadMeetsData();
+    loadBiosData();
+    recomputeStats();
 
     let summary;
     try {

--- a/stats/stats.js
+++ b/stats/stats.js
@@ -1,0 +1,757 @@
+/**
+ * OSU Gymnastics 2026 — Stats Module
+ *
+ * Pure Node.js module (no Express dependency).
+ * Computes all team, event, and individual stats from meets + bios data.
+ *
+ * Usage:
+ *   const { computeStats } = require('./stats/stats');
+ *   const bundle = computeStats(meetsData, biosData);
+ */
+
+'use strict';
+
+const EVENTS = ['vault', 'bars', 'beam', 'floor'];
+
+// ── Utility helpers ──────────────────────────────────────────────────────────
+
+function mean(arr) {
+  return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : null;
+}
+
+function stddev(arr) {
+  if (arr.length < 2) return 0;
+  const m = mean(arr);
+  return Math.sqrt(arr.reduce((s, v) => s + Math.pow(v - m, 2), 0) / (arr.length - 1));
+}
+
+function linReg(pts) {
+  const n = pts.length;
+  if (n < 2) return { slope: 0, intercept: 0 };
+  const sx = pts.reduce((s, p) => s + p.x, 0);
+  const sy = pts.reduce((s, p) => s + p.y, 0);
+  const sxy = pts.reduce((s, p) => s + p.x * p.y, 0);
+  const sx2 = pts.reduce((s, p) => s + p.x * p.x, 0);
+  const denom = n * sx2 - sx * sx;
+  if (denom === 0) return { slope: 0, intercept: sy / n };
+  const slope = (n * sxy - sx * sy) / denom;
+  const intercept = (sy - slope * sx) / n;
+  return { slope, intercept };
+}
+
+function safeMax(arr) { return arr.length ? Math.max(...arr) : null; }
+function safeMin(arr) { return arr.length ? Math.min(...arr) : null; }
+
+/**
+ * Deduplicate meets by competition date.
+ * Quad meets share a date — pick the first occurrence per date for team-level totals.
+ */
+function uniqueCompDays(meets) {
+  const seen = new Set();
+  const result = [];
+  const sorted = meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+  sorted.forEach(m => {
+    if (seen.has(m.date)) return;
+    if (!m.osuScore || m.osuScore <= 0) return;
+    seen.add(m.date);
+    result.push(m);
+  });
+  return result;
+}
+
+/**
+ * Get all unique OSU athlete names across all meets.
+ */
+function getAllAthleteNames(meets) {
+  const names = new Set();
+  meets.forEach(m => {
+    (m.athletes || [])
+      .filter(a => a.team === 'Oregon State')
+      .forEach(a => names.add(a.name));
+  });
+  return [...names].sort();
+}
+
+// ── Team-level stats ─────────────────────────────────────────────────────────
+
+function computeTeamStats(meets) {
+  const compDays = uniqueCompDays(meets);
+  const allScores = compDays.map(d => d.osuScore);
+  const homeScores = compDays.filter(d => d.isHome).map(d => d.osuScore);
+  const awayScores = compDays.filter(d => !d.isHome).map(d => d.osuScore);
+
+  // W-L by matchup
+  const wins = meets.filter(m => m.result === 'W').length;
+  const losses = meets.filter(m => m.result === 'L').length;
+
+  // W-L by competition day
+  const dayWins = new Set();
+  const dayLosses = new Set();
+  meets.forEach(m => {
+    if (m.result === 'W') dayWins.add(m.date);
+    else if (m.result === 'L') dayLosses.add(m.date);
+  });
+
+  const teamAvg = mean(allScores);
+  const homeAvg = mean(homeScores);
+  const awayAvg = mean(awayScores);
+  const seasonHigh = safeMax(allScores);
+  const seasonLow = safeMin(allScores);
+
+  // Season trajectory — first half vs second half
+  const half = Math.floor(allScores.length / 2);
+  const firstHalfAvg = half > 0 ? mean(allScores.slice(0, half)) : null;
+  const secondHalfAvg = half > 0 ? mean(allScores.slice(half)) : null;
+  const trajectory = firstHalfAvg != null && secondHalfAvg != null
+    ? secondHalfAvg - firstHalfAvg : null;
+
+  // Score trend array (for charts)
+  const scoreTrend = compDays.map(d => ({
+    date: d.date,
+    score: d.osuScore,
+    isHome: d.isHome,
+    opponent: d.opponent,
+    result: d.result,
+  }));
+
+  return {
+    record: { wins, losses },
+    dayRecord: { wins: dayWins.size, losses: dayLosses.size },
+    seasonAvg: teamAvg,
+    seasonHigh,
+    seasonLow,
+    homeAvg,
+    awayAvg,
+    trajectory,
+    firstHalfAvg,
+    secondHalfAvg,
+    scoreTrend,
+    meetsPlayed: compDays.length,
+  };
+}
+
+// ── Event trends ─────────────────────────────────────────────────────────────
+
+function computeEventTrends(meets) {
+  const compDays = uniqueCompDays(meets);
+  const sorted = compDays.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const trends = {};
+
+  EVENTS.forEach(ev => {
+    const pts = [];
+    sorted.forEach(m => {
+      const osuAthletes = (m.athletes || []).filter(a => a.team === 'Oregon State');
+      const evScores = osuAthletes
+        .map(a => a.scores[ev])
+        .filter(s => s !== undefined && s > 0);
+      if (evScores.length) {
+        pts.push({ date: m.date, avg: mean(evScores), teamTotal: m.events?.[ev]?.osu || null });
+      }
+    });
+
+    const avgs = pts.map(p => p.avg);
+    const seasonAvg = mean(avgs);
+    const recentAvg = pts.length >= 3 ? mean(pts.slice(-3).map(p => p.avg)) : seasonAvg;
+
+    // Trend direction: first 3 vs last 3
+    let trendDiff = null;
+    let trendSlope = null;
+    if (pts.length >= 4) {
+      const firstAvg = mean(pts.slice(0, 3).map(p => p.avg));
+      const lastAvg = mean(pts.slice(-3).map(p => p.avg));
+      trendDiff = lastAvg - firstAvg;
+    }
+    if (pts.length >= 3) {
+      trendSlope = linReg(pts.map((p, i) => ({ x: i, y: p.avg }))).slope;
+    }
+
+    // Rotation win/loss rate: did OSU beat opponent on this event?
+    let rotWins = 0, rotLosses = 0;
+    meets.forEach(m => {
+      if (m.events?.[ev]?.osu && m.events?.[ev]?.opponent) {
+        if (m.events[ev].osu > m.events[ev].opponent) rotWins++;
+        else if (m.events[ev].osu < m.events[ev].opponent) rotLosses++;
+      }
+    });
+
+    // Team-total based stats
+    const teamTotals = pts.map(p => p.teamTotal).filter(t => t != null);
+
+    trends[ev] = {
+      seasonAvg,
+      recentAvg,
+      trendDirection: trendDiff == null ? 'flat' : trendDiff > 0.03 ? 'up' : trendDiff < -0.03 ? 'down' : 'flat',
+      trendDiff,
+      trendSlope,
+      rotationRecord: { wins: rotWins, losses: rotLosses },
+      teamTotalAvg: mean(teamTotals),
+      teamTotalBest: safeMax(teamTotals),
+      meetByMeet: pts,
+    };
+  });
+
+  return trends;
+}
+
+// ── NQS (National Qualifying Score) ──────────────────────────────────────────
+
+function computeNQS(meets) {
+  // NQS = average of top 6 team totals from qualifying meets, dropping the lowest
+  // Exclude exhibition meets
+  const compDays = uniqueCompDays(meets);
+  const qualifying = compDays.filter(m => !m.exhibition);
+  const scores = qualifying.map(d => d.osuScore).sort((a, b) => b - a);
+
+  if (scores.length < 2) return { nqs: null, scoresUsed: scores, dropped: null };
+
+  // Top 6 scores
+  const top6 = scores.slice(0, 6);
+  // Drop lowest of those
+  const dropped = top6.length > 1 ? top6[top6.length - 1] : null;
+  const used = top6.length > 1 ? top6.slice(0, -1) : top6;
+  const nqs = mean(used);
+
+  return { nqs, scoresUsed: used, dropped, allScores: scores };
+}
+
+// ── Hot/Cold athletes ────────────────────────────────────────────────────────
+
+function computeHotColdAthletes(meets) {
+  const names = getAllAthleteNames(meets);
+  const sorted = meets.slice().sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  function athleteRecentAvg(name, n) {
+    const scores = [];
+    const dates = new Set();
+    sorted.forEach(m => {
+      if (dates.size >= n || dates.has(m.date)) return;
+      const a = (m.athletes || []).find(x => x.name === name && x.team === 'Oregon State');
+      if (!a) return;
+      const evScores = EVENTS.map(ev => a.scores[ev]).filter(s => s !== undefined && s > 0);
+      if (!evScores.length) return;
+      dates.add(m.date);
+      evScores.forEach(s => scores.push(s));
+    });
+    return mean(scores);
+  }
+
+  function athleteSeasonAvg(name) {
+    const scores = [];
+    const seen = new Set();
+    meets.forEach(m => {
+      if (seen.has(m.date)) return;
+      const a = (m.athletes || []).find(x => x.name === name && x.team === 'Oregon State');
+      if (!a) return;
+      const evScores = EVENTS.map(ev => a.scores[ev]).filter(s => s !== undefined && s > 0);
+      if (!evScores.length) return;
+      seen.add(m.date);
+      evScores.forEach(s => scores.push(s));
+    });
+    return mean(scores);
+  }
+
+  const form = names.map(name => {
+    const recent = athleteRecentAvg(name, 3);
+    const season = athleteSeasonAvg(name);
+    if (!recent || !season) return null;
+    return { name, recent, season, diff: recent - season };
+  }).filter(Boolean).sort((a, b) => b.diff - a.diff);
+
+  const hot = form.slice(0, 3).filter(g => g.diff > 0.01);
+  const cold = form.slice(-3).filter(g => g.diff < -0.01).reverse();
+
+  return { hot, cold, all: form };
+}
+
+// ── Event-level stats ────────────────────────────────────────────────────────
+
+function computeEventStats(meets, eventKey) {
+  const seasonData = [];
+  const seenDates = new Set();
+  const sorted = meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+
+  sorted.forEach(m => {
+    if (!m.events?.[eventKey]?.osu || m.events[eventKey].osu <= 0) return;
+    const key = m.date + '|' + m.id;
+    if (seenDates.has(key)) return;
+    seenDates.add(key);
+    seasonData.push({
+      meetId: m.id,
+      date: m.date,
+      opponent: m.opponent,
+      score: m.events[eventKey].osu,
+      oppScore: m.events[eventKey].opponent,
+      result: m.result,
+      isHome: m.isHome,
+    });
+  });
+
+  const scores = seasonData.map(d => d.score);
+  const homeScores = seasonData.filter(d => d.isHome).map(d => d.score);
+  const awayScores = seasonData.filter(d => !d.isHome).map(d => d.score);
+
+  return {
+    seasonAvg: mean(scores),
+    best: safeMax(scores),
+    worst: safeMin(scores),
+    mostRecent: seasonData.length ? seasonData[seasonData.length - 1].score : null,
+    stdDev: stddev(scores),
+    homeAvg: mean(homeScores),
+    awayAvg: mean(awayScores),
+    meetByMeet: seasonData,
+  };
+}
+
+function computeTopIndividualScores(meets, eventKey, limit = 10) {
+  const scores = [];
+  meets.forEach(m => {
+    (m.athletes || [])
+      .filter(a => a.team === 'Oregon State')
+      .forEach(a => {
+        if (a.scores[eventKey] !== undefined && a.scores[eventKey] > 0) {
+          scores.push({
+            name: a.name,
+            score: a.scores[eventKey],
+            date: m.date,
+            opponent: m.opponent,
+            meetId: m.id,
+          });
+        }
+      });
+  });
+  scores.sort((a, b) => b.score - a.score);
+  return scores.slice(0, limit);
+}
+
+function computeLineupPositionStats(meets, eventKey) {
+  // Average score by lineup position (1–6) across all meets
+  const byPosition = {};
+  meets.forEach(m => {
+    const lineup = m.lineups?.[eventKey];
+    if (!lineup || !Array.isArray(lineup)) return;
+    lineup.forEach(entry => {
+      const pos = entry.position;
+      if (!pos || !entry.score || entry.score <= 0) return;
+      if (!byPosition[pos]) byPosition[pos] = [];
+      byPosition[pos].push(entry.score);
+    });
+  });
+
+  const result = {};
+  Object.entries(byPosition).forEach(([pos, scores]) => {
+    result[pos] = {
+      avg: mean(scores),
+      best: safeMax(scores),
+      count: scores.length,
+    };
+  });
+
+  return result;
+}
+
+// ── Individual athlete stats ─────────────────────────────────────────────────
+
+function computeAthleteStats(meets, bios, athleteName) {
+  const sorted = meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const t0 = sorted.length ? new Date(sorted[0].date + 'T12:00:00') : new Date();
+
+  function evEntries(ev) {
+    const out = [];
+    const seen = new Set();
+    sorted.forEach(meet => {
+      if (seen.has(meet.date)) return;
+      const a = (meet.athletes || []).find(x => x.name === athleteName && x.team === 'Oregon State');
+      if (a && a.scores[ev] !== undefined) {
+        seen.add(meet.date);
+        out.push({
+          score: a.scores[ev],
+          date: meet.date,
+          isHome: meet.isHome,
+          result: meet.result,
+          gap: Math.abs((meet.osuScore || 0) - (meet.opponentScore || 0)),
+          day: Math.round((new Date(meet.date + 'T12:00:00') - t0) / 864e5),
+          opponent: meet.opponent,
+          meetId: meet.id,
+        });
+      }
+    });
+    return out;
+  }
+
+  const perEvent = {};
+  let totalAppearances = 0;
+
+  EVENTS.forEach(ev => {
+    const entries = evEntries(ev);
+    if (entries.length === 0) return;
+
+    const scores = entries.map(e => e.score);
+    const slope = entries.length >= 3
+      ? linReg(entries.map(e => ({ x: e.day, y: e.score }))).slope * 7 // per week
+      : null;
+
+    const home = entries.filter(e => e.isHome).map(e => e.score);
+    const away = entries.filter(e => !e.isHome).map(e => e.score);
+    const wins = entries.filter(e => e.result === 'W').map(e => e.score);
+    const losses = entries.filter(e => e.result === 'L').map(e => e.score);
+    const close = entries.filter(e => e.gap < 1.0).map(e => e.score);
+    const jan = entries.filter(e => new Date(e.date + 'T12:00:00').getMonth() === 0).map(e => e.score);
+    const late = entries.filter(e => new Date(e.date + 'T12:00:00').getMonth() > 0).map(e => e.score);
+
+    totalAppearances += entries.length;
+
+    perEvent[ev] = {
+      avg: mean(scores),
+      best: safeMax(scores),
+      worst: safeMin(scores),
+      stdDev: stddev(scores),
+      appearances: entries.length,
+      trendSlope: slope,
+      homeAvg: mean(home),
+      awayAvg: mean(away),
+      homeDelta: home.length && away.length ? mean(home) - mean(away) : null,
+      winAvg: mean(wins),
+      lossAvg: mean(losses),
+      winLossDelta: wins.length && losses.length ? mean(wins) - mean(losses) : null,
+      clutchAvg: mean(close),
+      janAvg: mean(jan),
+      lateAvg: mean(late),
+      seasonDelta: jan.length && late.length ? mean(late) - mean(jan) : null,
+      entries: entries.map(e => ({
+        score: e.score,
+        date: e.date,
+        opponent: e.opponent,
+        meetId: e.meetId,
+      })),
+    };
+  });
+
+  const bio = bios?.[athleteName] || null;
+
+  return {
+    name: athleteName,
+    bio: bio ? {
+      classYear: bio.classYear,
+      hometown: bio.hometown,
+      position: bio.position,
+      height: bio.height,
+    } : null,
+    totalAppearances,
+    events: perEvent,
+  };
+}
+
+function computeAllAthleteStats(meets, bios) {
+  const names = getAllAthleteNames(meets);
+  const result = {};
+  names.forEach(name => {
+    result[name] = computeAthleteStats(meets, bios, name);
+  });
+  return result;
+}
+
+// ── Leaderboard ──────────────────────────────────────────────────────────────
+
+function computeLeaderboards(meets) {
+  const leaderboards = {};
+
+  EVENTS.forEach(ev => {
+    const byGymnast = {};
+    const sorted = meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+
+    sorted.forEach(meet => {
+      (meet.athletes || []).forEach(a => {
+        if (a.scores[ev] === undefined || a.scores[ev] <= 0) return;
+        if (!byGymnast[a.name]) byGymnast[a.name] = { team: a.team, entries: [] };
+        byGymnast[a.name].entries.push({
+          score: a.scores[ev],
+          date: meet.date,
+          opponent: meet.opponent,
+          meetId: meet.id,
+        });
+      });
+    });
+
+    const list = Object.entries(byGymnast).map(([name, data]) => {
+      const scores = data.entries.map(e => e.score);
+      const best = data.entries.reduce((a, b) => a.score > b.score ? a : b);
+      return {
+        name,
+        team: data.team,
+        avg: mean(scores),
+        best: best.score,
+        bestMeetDate: best.date,
+        bestOpponent: best.opponent,
+        bestMeetId: best.meetId,
+        appearances: data.entries.length,
+        recent: data.entries[data.entries.length - 1],
+      };
+    });
+
+    // Sort by best score descending
+    list.sort((a, b) => b.best - a.best);
+    leaderboards[ev] = list;
+  });
+
+  return leaderboards;
+}
+
+// ── Heatmap ──────────────────────────────────────────────────────────────────
+
+function computeHeatmap(meets) {
+  const gymnData = {};
+  const seen = new Set();
+
+  meets.forEach(m => {
+    (m.athletes || [])
+      .filter(a => a.team === 'Oregon State')
+      .forEach(a => {
+        if (!gymnData[a.name]) gymnData[a.name] = { vault: [], bars: [], beam: [], floor: [] };
+        EVENTS.forEach(ev => {
+          const s = a.scores[ev];
+          if (s !== undefined && s > 0) {
+            const key = `${a.name}|${ev}|${m.date}`;
+            if (!seen.has(key)) {
+              seen.add(key);
+              gymnData[a.name][ev].push(s);
+            }
+          }
+        });
+      });
+  });
+
+  // Team averages per event
+  const teamAvgs = {};
+  EVENTS.forEach(ev => {
+    const all = Object.values(gymnData).flatMap(g => g[ev]);
+    teamAvgs[ev] = mean(all);
+  });
+
+  // Build matrix
+  const matrix = Object.entries(gymnData).map(([name, evData]) => {
+    const allScores = EVENTS.flatMap(ev => evData[ev]);
+    const overallAvg = mean(allScores);
+    const evAvgs = {};
+    const evDelta = {};
+    EVENTS.forEach(ev => {
+      evAvgs[ev] = mean(evData[ev]);
+      evDelta[ev] = evAvgs[ev] != null && teamAvgs[ev] != null
+        ? evAvgs[ev] - teamAvgs[ev] : null;
+    });
+    return { name, overallAvg, evAvgs, evDelta };
+  }).filter(g => g.overallAvg != null).sort((a, b) => b.overallAvg - a.overallAvg);
+
+  return { teamAvgs, gymnasts: matrix };
+}
+
+// ── Competitor stats ─────────────────────────────────────────────────────────
+
+function computeCompetitorStats(meets) {
+  const competitors = {};
+
+  meets.forEach(m => {
+    const ca = m.competitorAthletes || {};
+    Object.entries(ca).forEach(([team, athletes]) => {
+      if (!competitors[team]) {
+        competitors[team] = {
+          meetsPlayed: 0,
+          dates: [],
+          eventTotals: { vault: [], bars: [], beam: [], floor: [] },
+          individualScores: {},
+        };
+      }
+
+      competitors[team].meetsPlayed++;
+      competitors[team].dates.push(m.date);
+
+      // The athletes data is a dict of { name: { event: score } }
+      if (typeof athletes === 'object' && !Array.isArray(athletes)) {
+        Object.entries(athletes).forEach(([name, scores]) => {
+          if (typeof scores !== 'object') return;
+          if (!competitors[team].individualScores[name]) {
+            competitors[team].individualScores[name] = [];
+          }
+          Object.entries(scores).forEach(([ev, score]) => {
+            if (typeof score === 'number' && score > 0 && EVENTS.includes(ev)) {
+              competitors[team].eventTotals[ev].push(score);
+              competitors[team].individualScores[name].push({ event: ev, score, date: m.date });
+            }
+          });
+        });
+      }
+    });
+
+    // Also include opponent from the meet's events data
+    if (m.opponent && m.events) {
+      const team = m.opponent;
+      if (!competitors[team]) {
+        competitors[team] = {
+          meetsPlayed: 0,
+          dates: [],
+          eventTotals: { vault: [], bars: [], beam: [], floor: [] },
+          individualScores: {},
+        };
+      }
+    }
+  });
+
+  // Summarize per team
+  const result = {};
+  Object.entries(competitors).forEach(([team, data]) => {
+    const eventAvgs = {};
+    const topScorers = {};
+
+    EVENTS.forEach(ev => {
+      eventAvgs[ev] = mean(data.eventTotals[ev]);
+    });
+
+    // Top individual scores per event
+    EVENTS.forEach(ev => {
+      const scores = [];
+      Object.entries(data.individualScores).forEach(([name, entries]) => {
+        entries.filter(e => e.event === ev).forEach(e => {
+          scores.push({ name, score: e.score, date: e.date });
+        });
+      });
+      scores.sort((a, b) => b.score - a.score);
+      topScorers[ev] = scores.slice(0, 5);
+    });
+
+    result[team] = {
+      meetsPlayed: data.meetsPlayed,
+      dates: data.dates,
+      eventAvgs,
+      topScorers,
+      rosterSize: Object.keys(data.individualScores).length,
+    };
+  });
+
+  return result;
+}
+
+// ── Summary endpoint ─────────────────────────────────────────────────────────
+
+function computeSummary(meets) {
+  const compDays = uniqueCompDays(meets);
+  const wins = meets.filter(m => m.result === 'W').length;
+  const losses = meets.filter(m => m.result === 'L').length;
+  const allScores = compDays.map(d => d.osuScore);
+  const lastMeet = compDays.length ? compDays[compDays.length - 1] : null;
+
+  return {
+    record: `${wins}-${losses}`,
+    teamAvg: mean(allScores),
+    seasonHigh: safeMax(allScores),
+    meetsPlayed: compDays.length,
+    lastMeetDate: lastMeet?.date || null,
+    lastMeetOpponent: lastMeet?.opponent || null,
+    lastMeetScore: lastMeet?.osuScore || null,
+  };
+}
+
+// ── Main entry point ─────────────────────────────────────────────────────────
+
+function computeStats(meets, bios) {
+  if (!meets || !Array.isArray(meets)) meets = [];
+  if (!bios || typeof bios !== 'object') bios = {};
+
+  const team = computeTeamStats(meets);
+  const nqs = computeNQS(meets);
+  const hotCold = computeHotColdAthletes(meets);
+  const eventTrends = computeEventTrends(meets);
+
+  // Per-event stats
+  const events = {};
+  EVENTS.forEach(ev => {
+    events[ev] = {
+      ...computeEventStats(meets, ev),
+      topScores: computeTopIndividualScores(meets, ev, 10),
+      lineupPositionAvgs: computeLineupPositionStats(meets, ev),
+    };
+  });
+
+  const athletes = computeAllAthleteStats(meets, bios);
+  const leaderboards = computeLeaderboards(meets);
+  const heatmap = computeHeatmap(meets);
+  const competitors = computeCompetitorStats(meets);
+  const summary = computeSummary(meets);
+
+  return {
+    team: { ...team, nqs: nqs.nqs, nqsDetail: nqs, hotCold },
+    eventTrends,
+    events,
+    athletes,
+    leaderboards,
+    heatmap,
+    competitors,
+    summary,
+    computedAt: new Date().toISOString(),
+  };
+}
+
+// ── CLI test runner ──────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const fs = require('fs');
+  const path = require('path');
+  const dataDir = path.join(__dirname, '..', 'data');
+
+  let meets, bios;
+  try {
+    meets = JSON.parse(fs.readFileSync(path.join(dataDir, 'meets.json'), 'utf-8'));
+  } catch (e) {
+    console.error('Failed to load meets.json:', e.message);
+    process.exit(1);
+  }
+  try {
+    bios = JSON.parse(fs.readFileSync(path.join(dataDir, 'bios.json'), 'utf-8'));
+  } catch (e) {
+    bios = {};
+  }
+
+  const stats = computeStats(meets, bios);
+
+  console.log('=== OSU Gymnastics 2026 Stats Summary ===');
+  console.log(`Record: ${stats.team.record.wins}W - ${stats.team.record.losses}L`);
+  console.log(`Day Record: ${stats.team.dayRecord.wins}W - ${stats.team.dayRecord.losses}L`);
+  console.log(`Season Avg: ${stats.team.seasonAvg?.toFixed(3) || 'N/A'}`);
+  console.log(`Season High: ${stats.team.seasonHigh?.toFixed(3) || 'N/A'}`);
+  console.log(`NQS: ${stats.team.nqs?.toFixed(3) || 'N/A'}`);
+  console.log(`Home Avg: ${stats.team.homeAvg?.toFixed(3) || 'N/A'}`);
+  console.log(`Away Avg: ${stats.team.awayAvg?.toFixed(3) || 'N/A'}`);
+  console.log(`\n--- Event Trends ---`);
+  EVENTS.forEach(ev => {
+    const t = stats.eventTrends[ev];
+    console.log(`  ${ev}: avg=${t.seasonAvg?.toFixed(3)} recent=${t.recentAvg?.toFixed(3)} trend=${t.trendDirection} rotation=${t.rotationRecord.wins}W-${t.rotationRecord.losses}L`);
+  });
+  console.log(`\n--- Hot Athletes ---`);
+  stats.team.hotCold.hot.forEach(g => console.log(`  🔥 ${g.name}: ${g.recent.toFixed(3)} (+${g.diff.toFixed(3)})`));
+  console.log(`--- Cold Athletes ---`);
+  stats.team.hotCold.cold.forEach(g => console.log(`  🧊 ${g.name}: ${g.recent.toFixed(3)} (${g.diff.toFixed(3)})`));
+  console.log(`\nAthletes computed: ${Object.keys(stats.athletes).length}`);
+  console.log(`Competitors tracked: ${Object.keys(stats.competitors).length}`);
+  console.log(`Computed at: ${stats.computedAt}`);
+}
+
+// ── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  computeStats,
+  computeTeamStats,
+  computeEventTrends,
+  computeNQS,
+  computeHotColdAthletes,
+  computeEventStats,
+  computeTopIndividualScores,
+  computeLineupPositionStats,
+  computeAthleteStats,
+  computeAllAthleteStats,
+  computeLeaderboards,
+  computeHeatmap,
+  computeCompetitorStats,
+  computeSummary,
+  // Utilities exposed for testing
+  mean,
+  stddev,
+  linReg,
+};


### PR DESCRIPTION
Addresses issue #32

## What

Implements a server-side stats module that pre-computes all team, event, and individual analytics, exposes them via `/api/stats`, and has the frontend consume from the API instead of recomputing client-side.

## Changes

### Phase 1: Core Stats Module — `stats/stats.js`
- Pure Node.js module (no Express dependency) with `computeStats(meets, bios)` entry point
- **Team stats:** W-L record (matchup + competition day), season avg/high/low, home vs away avg, season trajectory, score trend array
- **Event trends:** Per-event season avg, recent avg (last 3), trend direction + slope, rotation win/loss rate
- **NQS:** National Qualifying Score (avg top 6 team totals, drop lowest)
- **Hot/Cold athletes:** Last 3 meets avg vs season avg, top 3 hot + top 3 cold
- **Event stats:** Season avg/best/worst, std dev, home vs away, meet-by-meet array
- **Top individual scores:** Ranked list per event with athlete, score, meet date, opponent
- **Lineup position stats:** Avg score by position (1–6) across all meets
- **Individual athlete stats:** Per event: avg, best, std dev, trend slope (linear regression), home Δ, win/loss Δ, clutch avg, Jan→late Δ
- **Leaderboards & heatmap:** Pre-computed for all events
- **Competitor stats:** Per competitor team: event avgs, top individual scores, roster size
- CLI test runner: `node stats/stats.js` prints summary

### Phase 2: Server API Endpoints
- `GET /api/stats` — full stats bundle
- `GET /api/stats/team` — team stats only
- `GET /api/stats/athletes` — all athletes
- `GET /api/stats/athletes/:name` — single athlete (URL-decoded)
- `GET /api/stats/events/:event` — single event (vault/bars/beam/floor)
- `GET /api/stats/summary` — lightweight health/embed endpoint
- Stats recompute on `/api/refresh`
- Bios loaded server-side at startup (deduplicating the file read)

### Phase 3: Frontend Integration
- `loadData()` fetches `/api/stats` alongside existing data
- Mission Control uses `statsCache.team` (with full inline fallback)
- Heat map uses `statsCache.heatmap`
- Leaderboards use `statsCache.leaderboards`
- Gymnast insights use `statsCache.athletes`
- **New:** NQS display in Mission Control stats row
- **New:** Lineup position analysis panel in event detail view
- **New:** Competitor roster section in meet detail view
- Full defensive fallback: if `/api/stats` fails, inline computation still works

### Phase 4: Cleanup & Documentation
- README updated with all `/api/stats/*` endpoints and stats bundle schema
- No new npm dependencies (pure Node.js math)