### PR TITLE
feat: Stats module + all missing analysis features (AA, NQS, Lineup, Rankings, Comparison)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2686,3 +2686,267 @@ main {
     grid-template-columns: 1fr;
   }
 }
+
+/* ===== Stats Module Components ===== */
+
+/* NQS Display */
+.nqs-dropped {
+  opacity: 0.5;
+}
+.nqs-dropped-score {
+  text-decoration: line-through;
+  color: var(--text-muted) !important;
+}
+.nqs-drop-label {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--red);
+  background: rgba(224, 92, 74, 0.15);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  margin-left: 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.nqs-summary {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: rgba(215, 63, 9, 0.08);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+.nqs-label {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--orange);
+  background: rgba(215, 63, 9, 0.15);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  margin-right: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Team Season Rankings */
+.team-rankings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.team-rankings-table th {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.team-rankings-table td {
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid rgba(61, 50, 40, 0.3);
+  color: var(--text);
+}
+.osu-highlight-row {
+  background: rgba(215, 63, 9, 0.1);
+}
+.osu-highlight-row td {
+  border-bottom-color: rgba(215, 63, 9, 0.2);
+}
+
+/* Momentum arrow */
+.momentum-up {
+  color: var(--green);
+  font-weight: 700;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.momentum-down {
+  color: var(--red);
+  font-weight: 700;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Compare Mode */
+.compare-toggle-btn {
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-family: Oswald, sans-serif;
+  cursor: pointer;
+  transition: var(--transition);
+  margin-left: 0.5rem;
+  white-space: nowrap;
+}
+.compare-toggle-btn:hover,
+.compare-toggle-btn.active {
+  background: var(--orange-dark);
+  border-color: var(--orange);
+  color: #fff;
+}
+.compare-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: rgba(215, 63, 9, 0.08);
+  border: 1px solid rgba(215, 63, 9, 0.2);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+.compare-bar-text {
+  flex: 1;
+  color: var(--text);
+  font-size: 0.85rem;
+}
+.compare-go-btn {
+  background: var(--orange-dark);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 1rem;
+  border-radius: 6px;
+  font-family: Oswald, sans-serif;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+.compare-go-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.compare-cancel-btn {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.gymnast-card.compare-selected {
+  border: 2px solid var(--orange);
+  box-shadow: 0 0 12px rgba(215, 63, 9, 0.3);
+}
+.compare-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin: 1.5rem 0;
+}
+.compare-athlete {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+.compare-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.compare-avatar-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--card);
+  color: var(--text);
+  font-family: Oswald, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+.compare-vs {
+  font-family: Oswald, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+.compare-name {
+  font-family: Oswald, sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: center;
+}
+.compare-table th,
+.compare-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid rgba(61, 50, 40, 0.3);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+.compare-table th {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.compare-winner {
+  color: var(--green) !important;
+  font-weight: 600;
+}
+.compare-sparks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+.compare-spark {
+  text-align: center;
+}
+.compare-spark-title {
+  font-family: Oswald, sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.3rem;
+}
+.compare-spark svg {
+  width: 100%;
+  max-height: 60px;
+}
+.compare-spark-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+/* Search container flex for compare button */
+.search-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.search-container .search-input {
+  flex: 1;
+}
+
+@media (max-width: 600px) {
+  .compare-header {
+    gap: 1rem;
+  }
+  .compare-avatar {
+    width: 60px;
+    height: 60px;
+  }
+  .compare-sparks {
+    grid-template-columns: 1fr;
+  }
+  .compare-bar {
+    flex-wrap: wrap;
+  }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2687,6 +2687,321 @@ main {
   }
 }
 
+/* ===== Stats Module — New UI Components ===== */
+
+/* NQS Breakdown in meet detail */
+.nqs-dropped {
+  opacity: 0.45;
+}
+.nqs-dropped-score {
+  text-decoration: line-through;
+  color: var(--text-muted) !important;
+}
+.nqs-drop-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: #e74c3c;
+  background: rgba(231, 76, 60, 0.15);
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-left: 0.3rem;
+  vertical-align: middle;
+}
+.nqs-summary {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: rgba(215, 63, 9, 0.08);
+  border: 1px solid rgba(215, 63, 9, 0.2);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.nqs-label {
+  font-family: Oswald, sans-serif;
+  font-weight: 700;
+  font-size: 0.7rem;
+  color: var(--orange);
+  background: rgba(215, 63, 9, 0.2);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  letter-spacing: 0.05em;
+}
+
+/* NQS chip on mission control event cards */
+.mc-ev-nqs {
+  font-size: 0.65rem;
+  font-family: Oswald, sans-serif;
+  font-weight: 600;
+  color: var(--orange);
+  background: rgba(215, 63, 9, 0.1);
+  border: 1px solid rgba(215, 63, 9, 0.2);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  margin-top: 0.25rem;
+  letter-spacing: 0.03em;
+}
+
+/* Momentum indicators */
+.momentum-up {
+  color: #2ecc71;
+  font-weight: 700;
+}
+.momentum-down {
+  color: #e74c3c;
+  font-weight: 700;
+}
+
+/* Team Season Rankings */
+.team-rankings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.team-rankings-table th {
+  text-align: left;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.team-rankings-table td {
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  color: #ccc;
+}
+.team-rankings-table tr:hover {
+  background: rgba(255,255,255,0.03);
+}
+.osu-highlight-row {
+  background: rgba(215, 63, 9, 0.08) !important;
+}
+.osu-highlight-row td {
+  color: #fff;
+}
+
+/* Comparison View */
+.compare-toggle-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  color: #ccc;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: Inter, sans-serif;
+  transition: all 0.2s;
+}
+.compare-toggle-btn:hover {
+  background: rgba(215, 63, 9, 0.15);
+  border-color: var(--orange);
+  color: var(--orange);
+}
+.compare-toggle-btn.active {
+  background: rgba(215, 63, 9, 0.2);
+  border-color: var(--orange);
+  color: var(--orange);
+  font-weight: 600;
+}
+.compare-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: rgba(215, 63, 9, 0.08);
+  border: 1px solid rgba(215, 63, 9, 0.2);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+.compare-bar-text {
+  flex: 1;
+  font-size: 0.85rem;
+  color: #ccc;
+}
+.compare-bar-go {
+  background: var(--orange);
+  color: #fff;
+  border: none;
+  padding: 0.35rem 0.75rem;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: Oswald, sans-serif;
+}
+.compare-bar-go:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.compare-bar-clear {
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.15);
+  color: #aaa;
+  padding: 0.3rem 0.6rem;
+  border-radius: 5px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.gymnast-card.compare-selected {
+  border: 2px solid var(--orange);
+  box-shadow: 0 0 12px rgba(215, 63, 9, 0.3);
+}
+.compare-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1.5rem 1rem;
+  margin-bottom: 1rem;
+}
+.compare-athlete {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+.compare-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid rgba(255,255,255,0.1);
+}
+.compare-avatar-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #333;
+  color: #fff;
+  font-family: Oswald, sans-serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+.compare-name {
+  font-family: Oswald, sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+.compare-vs {
+  font-family: Oswald, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: center;
+}
+.compare-table th {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.compare-table td {
+  padding: 0.5rem 0.4rem;
+  font-size: 0.9rem;
+  color: #ccc;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.compare-winner {
+  color: #2ecc71 !important;
+  font-weight: 600;
+}
+.compare-sparks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+.compare-spark {
+  background: rgba(255,255,255,0.03);
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+.compare-spark-title {
+  font-family: Oswald, sans-serif;
+  font-size: 0.85rem;
+  color: var(--orange);
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+.compare-spark-legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  margin-top: 0.3rem;
+}
+
+/* Lineup Position Analysis */
+.position-spotlight {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+.position-spotlight-card {
+  flex: 1;
+  min-width: 140px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+.position-spotlight-card .spotlight-role {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+.position-spotlight-card .spotlight-name {
+  font-family: Oswald, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+}
+.position-spotlight-card .spotlight-stat {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+/* Score Distribution */
+.distribution-chart svg {
+  width: 100%;
+  max-width: 500px;
+}
+
+@media (max-width: 600px) {
+  .compare-header {
+    gap: 1rem;
+  }
+  .compare-avatar {
+    width: 60px;
+    height: 60px;
+  }
+  .compare-sparks {
+    grid-template-columns: 1fr;
+  }
+  .team-rankings-table {
+    font-size: 0.75rem;
+  }
+  .team-rankings-table th,
+  .team-rankings-table td {
+    padding: 0.35rem 0.25rem;
+  }
+}
+
 /* ===== Stats Module Components ===== */
 
 /* NQS Display */

--- a/public/index.html
+++ b/public/index.html
@@ -56,6 +56,12 @@
         <div class="chart-container" id="scoreTrend"></div>
       </div>
 
+      <!-- Team Season Rankings -->
+      <div class="section-card" id="teamRankingsSection" style="display:none;">
+        <h2 class="section-title">Team Season Rankings</h2>
+        <div id="teamRankingsContent"></div>
+      </div>
+
       <!-- Filters -->
       <div class="filter-bar">
         <button class="filter-btn active" data-filter="all">All</button>
@@ -79,8 +85,16 @@
     <section id="view-gymnasts" class="view" style="display:none;">
       <div class="search-container">
         <input type="text" id="gymnastSearch" class="search-input" placeholder="Search gymnasts by name...">
+        <button class="compare-toggle-btn" id="compareToggleBtn">Compare Athletes</button>
+      </div>
+      <div class="compare-bar" id="compareBar" style="display:none;">
+        <span class="compare-bar-text" id="compareBarText">Select 2 athletes to compare</span>
+        <button class="compare-go-btn" id="compareGoBtn" disabled>Compare</button>
+        <button class="compare-cancel-btn" id="compareCancelBtn">Cancel</button>
       </div>
       <div class="gymnast-cards" id="gymnastCards"></div>
+      <!-- Gymnast Comparison Panel -->
+      <div id="gymnastComparison" style="display:none;"></div>
       <!-- Gymnast Detail (shown when clicked) -->
       <div id="gymnastDetail" style="display:none;"></div>
     </section>
@@ -137,8 +151,8 @@
   <!-- Toast Container -->
   <div id="toastContainer" class="toast-container"></div>
 
-  <script src="js/search.js?v=0"></script>
   <script src="js/stats.js?v=0"></script>
+  <script src="js/search.js?v=0"></script>
   <script src="js/app.js?v=0"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,7 @@
   <div id="toastContainer" class="toast-container"></div>
 
   <script src="js/search.js?v=0"></script>
+  <script src="js/stats.js?v=0"></script>
   <script src="js/app.js?v=0"></script>
 </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -45,20 +45,10 @@
     return meets.some(m => m.status === 'in_progress');
   }
 
-  // ===== Shared Stats Helpers =====
-  function mean(arr) { return arr.length ? arr.reduce((s,v)=>s+v,0)/arr.length : null; }
-  function stddev(arr) {
-    if (arr.length < 2) return 0;
-    const m = mean(arr);
-    return Math.sqrt(arr.reduce((s,v)=>s+Math.pow(v-m,2),0)/(arr.length-1));
-  }
-  function pearson(xs, ys) {
-    const n = xs.length; if (n < 3) return null;
-    const mx = mean(xs), my = mean(ys);
-    const num = xs.reduce((s,x,i)=>s+(x-mx)*(ys[i]-my),0);
-    const den = Math.sqrt(xs.reduce((s,x)=>s+Math.pow(x-mx,2),0)*ys.reduce((s,y)=>s+Math.pow(y-my,2),0));
-    return den === 0 ? null : num/den;
-  }
+  // ===== Shared Stats Helpers (delegated to Stats module) =====
+  const mean = Stats.mean;
+  const stddev = Stats.stddev;
+  const pearson = Stats.pearson;
   function fmt(n, dp=3) { return n!=null&&!isNaN(n) ? n.toFixed(dp) : '—'; }
 
   // ===== Toast Notifications =====
@@ -3283,13 +3273,7 @@
   // ===== Insights =====
   function renderInsights() {
     // --- helpers ---
-    function linReg(pts) {
-      const n = pts.length;
-      if (n < 2) return {slope:0};
-      const sx=pts.reduce((s,p)=>s+p.x,0), sy=pts.reduce((s,p)=>s+p.y,0);
-      const sxy=pts.reduce((s,p)=>s+p.x*p.y,0), sx2=pts.reduce((s,p)=>s+p.x*p.x,0);
-      return {slope:(n*sxy-sx*sy)/(n*sx2-sx*sx)||0};
-    }
+    const linReg = Stats.linReg;
     function fmtDiff(n) { if (typeof n !== 'number' || isNaN(n)) return '—'; return (n>=0?'+':'')+n.toFixed(3); }
 
     const EVS = ['vault','bars','beam','floor'];
@@ -4073,12 +4057,8 @@
   }
 // ===== Season Wild Stats =====
   function renderSeasonWildStats() {
-    // ── Shared stats helpers ────────────────────────────────────────────────
-    function sd(arr) {
-      if(arr.length < 2) return null;
-      const m = mean(arr);
-      return Math.sqrt(arr.reduce((s,v)=>s+Math.pow(v-m,2),0)/(arr.length-1));
-    }
+    // ── Shared stats helpers (delegated to Stats module) ────────────────────
+    const sd = Stats.stddev;
     function corrStrength(r) {
       const a = Math.abs(r);
       if(a < 0.2) return 'negligible';

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,6 +12,8 @@
   let lastRefreshedTime = null;
   let autoRefreshInterval = null;
   let autoRefreshEnabled = false;
+  let compareMode = false;
+  let compareSelections = [];
 
   const EVENT_NAMES = {
     vault: 'Vault', bars: 'Bars', beam: 'Beam', floor: 'Floor', aa: 'All-Around'
@@ -46,9 +48,9 @@
   }
 
   // ===== Shared Stats Helpers (delegated to Stats module) =====
-  const mean = Stats.mean;
-  const stddev = Stats.stddev;
-  const pearson = Stats.pearson;
+  const mean = StatsLib.mean;
+  const stddev = StatsLib.stddev;
+  const pearson = StatsLib.pearson;
   function fmt(n, dp=3) { return n!=null&&!isNaN(n) ? n.toFixed(dp) : '—'; }
 
   // ===== Toast Notifications =====
@@ -418,7 +420,15 @@
         <div class="mc-stat-card">
           <div class="mc-stat-value" id="mcAvg">0.000</div>
           <div class="mc-stat-label">Team Avg</div>
-          <div class="mc-context">${trajArrow} ${trajLabel}</div>
+          <div class="mc-context">${trajArrow} ${trajLabel}${(() => {
+            const rolling = StatsLib.getRollingAverage(meets, 3).filter(r => r.avg != null);
+            if (rolling.length < 2) return '';
+            const last = rolling[rolling.length - 1].avg;
+            const prev = rolling[rolling.length - 2].avg;
+            const diff = last - prev;
+            const arrow = diff > 0.1 ? ' <span class="momentum-up">↑</span>' : diff < -0.1 ? ' <span class="momentum-down">↓</span>' : '';
+            return arrow;
+          })()}</div>
         </div>
         <div class="mc-stat-card">
           <div class="mc-stat-value" id="mcHome">0.000</div>
@@ -443,10 +453,21 @@
           const arrow = d.trend > 0.03 ? '▲' : d.trend < -0.03 ? '▼' : '→';
           const arrowColor = d.trend > 0.03 ? '#2ecc71' : d.trend < -0.03 ? '#e74c3c' : '#aaa';
           const barPct = Math.round(((d.avg||0) - 9.6) / 0.4 * 100);
+          // NQS chip: average of top 6 NQS values across the season
+          const nqsVals = [];
+          meets.forEach(m => {
+            const nqsData = StatsLib.getNQSBreakdown(m, ev);
+            if (nqsData) nqsVals.push(nqsData.nqs);
+          });
+          nqsVals.sort((a,b) => b - a);
+          const topNqs = nqsVals.slice(0, 6);
+          const projNqs = topNqs.length ? (topNqs.reduce((s,v)=>s+v,0)/topNqs.length) : null;
+          const nqsChip = projNqs ? `<div class="mc-ev-nqs" title="Projected NQS (avg of best ${topNqs.length} meets)">NQS ${projNqs.toFixed(3)}</div>` : '';
           return `<div class="mc-event-card">
             <div class="mc-ev-label">${EVemoji[ev]} ${EVlabel[ev]}</div>
             <div class="mc-ev-avg">${d.avg != null ? d.avg.toFixed(3) : '—'}</div>
             <div class="mc-ev-trend" style="color:${arrowColor}">${arrow} ${d.trend!=null?((d.trend>=0?'+':'')+d.trend.toFixed(3)+' trend'):'—'}</div>
+            ${nqsChip}
             <div class="mc-ev-bar-wrap"><div class="mc-ev-bar" style="width:${Math.max(0,Math.min(100,barPct))}%"></div></div>
           </div>`;
         }).join('')}
@@ -789,7 +810,46 @@
     renderMissionControl();
 
     renderScoreTrend();
+    renderTeamRankings();
     renderMeetCards();
+  }
+
+  function renderTeamRankings() {
+    const section = document.getElementById('teamRankingsSection');
+    const content = document.getElementById('teamRankingsContent');
+    if (!section || !content) return;
+
+    const rankings = StatsLib.getSeasonRankings(meets);
+    if (rankings.length === 0) {
+      section.style.display = 'none';
+      return;
+    }
+    section.style.display = '';
+
+    content.innerHTML = `
+      <p style="color:var(--text-muted);font-size:0.8rem;margin-bottom:0.75rem;">Averages from quad meet data (${rankings[0].appearances > 0 ? rankings[0].appearances : '—'} max appearances). Teams ranked by average total.</p>
+      <div style="overflow-x:auto;">
+        <table class="team-rankings-table">
+          <thead><tr><th>#</th><th>Team</th><th>Avg Total</th><th>Best</th><th>VT</th><th>UB</th><th>BB</th><th>FX</th><th>Meets</th></tr></thead>
+          <tbody>
+            ${rankings.map((t, i) => {
+              const isOSU = t.team.toLowerCase().includes('oregon');
+              return `
+              <tr class="${isOSU ? 'osu-highlight-row' : ''}">
+                <td>${i + 1}</td>
+                <td style="${isOSU ? 'color:#D73F09;font-weight:700;' : ''}">${t.team}</td>
+                <td style="font-family:Oswald;font-weight:600;${isOSU ? 'color:#D73F09;' : ''}">${t.avgTotal.toFixed(3)}</td>
+                <td>${t.bestTotal ? t.bestTotal.toFixed(3) : '—'}</td>
+                <td>${t.vault ? t.vault.toFixed(3) : '—'}</td>
+                <td>${t.bars ? t.bars.toFixed(3) : '—'}</td>
+                <td>${t.beam ? t.beam.toFixed(3) : '—'}</td>
+                <td>${t.floor ? t.floor.toFixed(3) : '—'}</td>
+                <td>${t.appearances}</td>
+              </tr>`;
+            }).join('')}
+          </tbody>
+        </table>
+      </div>`;
   }
 
   function renderScoreTrend() {
@@ -843,13 +903,46 @@
       return `<text x="${x}" y="${h - 5}" text-anchor="middle" fill="#999" font-size="9" font-family="Inter">${formatDate(m.date)}</text>`;
     }).join('');
 
+    // Rolling 3-meet average overlay
+    const rolling = StatsLib.getRollingAverage(meets, 3);
+    const rollingValid = rolling.filter(r => r.avg != null);
+    let rollingPath = '';
+    if (rollingValid.length >= 2) {
+      // Map rolling entries to the same x positions as scoredMeets by date
+      const dateToIdx = {};
+      scoredMeets.forEach((m, i) => { dateToIdx[m.date] = i; });
+      rollingPath = rollingValid.map((r, ri) => {
+        const idx = dateToIdx[r.date];
+        if (idx === undefined) return '';
+        const x = xScale(idx).toFixed(1);
+        const y = yScale(r.avg).toFixed(1);
+        return `${ri === 0 ? 'M' : 'L'}${x},${y}`;
+      }).filter(Boolean).join(' ');
+      if (rollingPath) {
+        rollingPath = `<path d="${rollingPath}" fill="none" stroke="#3498db" stroke-width="1.5" stroke-dasharray="6,3" stroke-linejoin="round" opacity="0.7">
+          <title>3-meet rolling average</title>
+        </path>`;
+      }
+    }
+
+    // Legend
+    const legend = rollingValid.length >= 2 ? `
+      <g transform="translate(${w - pad.right - 150}, ${pad.top})">
+        <line x1="0" y1="6" x2="20" y2="6" stroke="var(--orange)" stroke-width="2.5"/>
+        <text x="24" y="10" fill="#999" font-size="9" font-family="Inter">Score</text>
+        <line x1="0" y1="20" x2="20" y2="20" stroke="#3498db" stroke-width="1.5" stroke-dasharray="6,3"/>
+        <text x="24" y="24" fill="#999" font-size="9" font-family="Inter">3-meet avg</text>
+      </g>` : '';
+
     container.innerHTML = `
       <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">
         ${yGridLines}
+        ${rollingPath}
         <path d="${pathD}" fill="none" stroke="var(--orange)" stroke-width="2.5" stroke-linejoin="round"/>
         ${dots}
         ${yLabels}
         ${xLabels}
+        ${legend}
       </svg>
     `;
   }
@@ -1651,19 +1744,35 @@
       const barPct = ((osuScore / 50) * 100).toFixed(1);
 
       let rows;
+      let nqsHtml = '';
       if (meet.lineups && meet.lineups[event] && meet.lineups[event].length > 0) {
         // Render in competition order using lineup data
         const lineup = meet.lineups[event];
         const topScore = Math.max(...lineup.map(e => e.score));
+
+        // NQS: if 6 entries, lowest is dropped, top 5 count
+        const scores = lineup.map(e => e.score).sort((a,b) => a - b);
+        const isDrop = lineup.length >= 6;
+        const dropScore = isDrop ? scores[0] : null;
+        // Handle ties: only mark one as dropped
+        let dropMarked = false;
+
         rows = lineup.map(entry => {
           const isTop = entry.score === topScore;
+          const isDropped = isDrop && !dropMarked && entry.score === dropScore;
+          if (isDropped) dropMarked = true;
           return `
-            <tr class="lineup-row">
+            <tr class="lineup-row${isDropped ? ' nqs-dropped' : ''}">
               <td style="color:#aaa;font-size:0.75rem;font-family:monospace;width:1.5rem;">${entry.position}</td>
-              <td><span class="clickable-name lineup-gymnast" data-gymnast="${entry.name}" data-event="${event}" data-meet="${meet.id}">${entry.name}</span></td>
-              <td class="score-cell${isTop ? ' score-top' : ''}">${entry.score.toFixed(3)}</td>
+              <td><span class="clickable-name lineup-gymnast" data-gymnast="${entry.name}" data-event="${event}" data-meet="${meet.id}">${entry.name}</span>${isDropped ? ' <span class="nqs-drop-label">DROP</span>' : ''}</td>
+              <td class="score-cell${isTop ? ' score-top' : ''}${isDropped ? ' nqs-dropped-score' : ''}">${entry.score.toFixed(3)}</td>
             </tr>`;
         }).join('');
+
+        if (isDrop) {
+          const nqsTotal = scores.slice(1).reduce((s,v) => s + v, 0);
+          nqsHtml = `<div class="nqs-summary"><span class="nqs-label">NQS</span> Top 5 count: <strong>${nqsTotal.toFixed(3)}</strong></div>`;
+        }
       } else {
         // Fallback: sort by score descending (legacy behaviour)
         const eventAthletes = meet.athletes
@@ -1690,6 +1799,7 @@
             <thead><tr><th>#</th><th>Athlete</th><th style="text-align:right">Score</th></tr></thead>
             <tbody>${rows || '<tr><td colspan="3" style="color:var(--text-muted)">No data</td></tr>'}</tbody>
           </table>
+          ${nqsHtml}
         </div>`;
     }).join('');
 
@@ -2097,6 +2207,154 @@
           <div class="gymnast-averages">${avgStats}</div>
         </div>`;
     }).join('');
+  }
+
+  function toggleCompareMode() {
+    compareMode = !compareMode;
+    compareSelections = [];
+    const bar = document.getElementById('compareBar');
+    const btn = document.getElementById('compareToggleBtn');
+    const comp = document.getElementById('gymnastComparison');
+    if (compareMode) {
+      bar.style.display = 'flex';
+      btn.textContent = 'Exit Compare';
+      btn.classList.add('active');
+      comp.style.display = 'none';
+      updateCompareBar();
+    } else {
+      bar.style.display = 'none';
+      btn.textContent = 'Compare Athletes';
+      btn.classList.remove('active');
+      comp.style.display = 'none';
+      document.querySelectorAll('.gymnast-card.compare-selected').forEach(c => c.classList.remove('compare-selected'));
+    }
+  }
+
+  function updateCompareBar() {
+    const text = document.getElementById('compareBarText');
+    const goBtn = document.getElementById('compareGoBtn');
+    if (compareSelections.length === 0) {
+      text.textContent = 'Select 2 athletes to compare';
+    } else if (compareSelections.length === 1) {
+      text.textContent = `Selected: ${compareSelections[0]} — pick one more`;
+    } else {
+      text.textContent = `${compareSelections[0]} vs ${compareSelections[1]}`;
+    }
+    goBtn.disabled = compareSelections.length < 2;
+  }
+
+  function handleCompareSelect(name) {
+    const idx = compareSelections.indexOf(name);
+    if (idx >= 0) {
+      compareSelections.splice(idx, 1);
+    } else if (compareSelections.length < 2) {
+      compareSelections.push(name);
+    } else {
+      // Replace second selection
+      compareSelections[1] = name;
+    }
+    // Update card visual
+    document.querySelectorAll('.gymnast-card').forEach(c => {
+      c.classList.toggle('compare-selected', compareSelections.includes(c.dataset.gymnast));
+    });
+    updateCompareBar();
+  }
+
+  function renderComparison() {
+    if (compareSelections.length < 2) return;
+    const [name1, name2] = compareSelections;
+    const s1 = StatsLib.getAthleteStats(meets, name1);
+    const s2 = StatsLib.getAthleteStats(meets, name2);
+
+    const EVENTS = ['vault', 'bars', 'beam', 'floor'];
+    const EVN = { vault: 'Vault', bars: 'Bars', beam: 'Beam', floor: 'Floor' };
+
+    // Build side-by-side stats table
+    const rows = EVENTS.map(ev => {
+      const a = s1.perEvent[ev], b = s2.perEvent[ev];
+      if (!a && !b) return '';
+      const avgA = a ? a.avg.toFixed(3) : '—';
+      const avgB = b ? b.avg.toFixed(3) : '—';
+      const bestA = a ? a.best.toFixed(3) : '—';
+      const bestB = b ? b.best.toFixed(3) : '—';
+      const winClass1 = a && b && a.avg > b.avg ? 'compare-winner' : '';
+      const winClass2 = a && b && b.avg > a.avg ? 'compare-winner' : '';
+      return `<tr>
+        <td class="${winClass1}">${avgA}</td>
+        <td class="${winClass1}">${bestA}</td>
+        <td style="font-weight:600;color:var(--orange)">${EVN[ev]}</td>
+        <td class="${winClass2}">${avgB}</td>
+        <td class="${winClass2}">${bestB}</td>
+      </tr>`;
+    }).join('');
+
+    // Sparkline overlay for shared events
+    let sparkOverlays = '';
+    EVENTS.forEach(ev => {
+      const e1 = s1.perEvent[ev], e2 = s2.perEvent[ev];
+      if (!e1 || !e2 || e1.entries.length < 2 || e2.entries.length < 2) return;
+      const allScores = [...e1.scores, ...e2.scores];
+      const minS = Math.min(...allScores) - 0.05;
+      const maxS = Math.max(...allScores) + 0.05;
+      const w = 300, h = 60;
+      function mkPath(entries, color) {
+        const pts = entries.map((e, i) => {
+          const x = 10 + (i / (entries.length - 1)) * (w - 20);
+          const y = 5 + (1 - (e.score - minS) / (maxS - minS)) * (h - 10);
+          return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+        }).join(' ');
+        return `<path d="${pts}" fill="none" stroke="${color}" stroke-width="2" opacity="0.8"/>`;
+      }
+      sparkOverlays += `
+        <div class="compare-spark">
+          <div class="compare-spark-title">${EVN[ev]}</div>
+          <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">
+            ${mkPath(e1.entries, '#D73F09')}
+            ${mkPath(e2.entries, '#3498db')}
+          </svg>
+          <div class="compare-spark-legend">
+            <span style="color:#D73F09">${name1.split(' ')[1] || name1}</span>
+            <span style="color:#3498db">${name2.split(' ')[1] || name2}</span>
+          </div>
+        </div>`;
+    });
+
+    const photo1 = photos[name1];
+    const photo2 = photos[name2];
+    const av1 = photo1 ? `<img src="${photo1}" class="compare-avatar" alt="${name1}">` : `<div class="compare-avatar compare-avatar-initials">${name1.split(' ').map(n=>n[0]).join('')}</div>`;
+    const av2 = photo2 ? `<img src="${photo2}" class="compare-avatar" alt="${name2}">` : `<div class="compare-avatar compare-avatar-initials">${name2.split(' ').map(n=>n[0]).join('')}</div>`;
+
+    const panel = document.getElementById('gymnastComparison');
+    panel.style.display = 'block';
+    document.getElementById('gymnastCards').style.display = 'none';
+
+    panel.innerHTML = `
+      <button class="back-btn" id="backFromCompare">← Back to Gymnasts</button>
+      <div class="compare-header">
+        <div class="compare-athlete">${av1}<div class="compare-name" style="color:#D73F09">${name1}</div></div>
+        <div class="compare-vs">VS</div>
+        <div class="compare-athlete">${av2}<div class="compare-name" style="color:#3498db">${name2}</div></div>
+      </div>
+      <div class="section-card">
+        <h2 class="section-title">Head-to-Head Stats</h2>
+        <table class="compare-table">
+          <thead><tr><th>Avg</th><th>Best</th><th>Event</th><th>Avg</th><th>Best</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+      ${sparkOverlays ? `<div class="section-card"><h2 class="section-title">Score Trends Overlay</h2><div class="compare-sparks">${sparkOverlays}</div></div>` : ''}
+    `;
+
+    document.getElementById('backFromCompare').addEventListener('click', () => {
+      panel.style.display = 'none';
+      document.getElementById('gymnastCards').style.display = 'grid';
+      compareMode = false;
+      compareSelections = [];
+      document.getElementById('compareBar').style.display = 'none';
+      document.getElementById('compareToggleBtn').textContent = 'Compare Athletes';
+      document.getElementById('compareToggleBtn').classList.remove('active');
+      document.querySelectorAll('.gymnast-card.compare-selected').forEach(c => c.classList.remove('compare-selected'));
+    });
   }
 
   function showGymnastProfile(name) {
@@ -2799,6 +3057,48 @@
         </div>
       </div>`;
 
+    // Score Distribution chart (box-and-whisker)
+    const dist = StatsLib.getScoreDistribution(meets, eventKey);
+    let distributionChart = '';
+    if (dist.scores.length >= 5) {
+      const dW = 500, dH = 70;
+      const dPad = { left: 50, right: 20 };
+      const usable = dW - dPad.left - dPad.right;
+      const dMin = dist.min - 0.05;
+      const dMax = dist.max + 0.05;
+      const dRange = dMax - dMin || 0.1;
+      const sx = v => dPad.left + ((v - dMin) / dRange) * usable;
+
+      const boxY = 20, boxH = 30;
+      const whiskerY = boxY + boxH / 2;
+
+      distributionChart = `
+        <div class="section-card">
+          <h2 class="section-title">Score Distribution</h2>
+          <p style="color:var(--text-muted);font-size:0.8rem;margin-bottom:0.5rem;">Individual OSU ${evName} scores — min / Q1 / median / Q3 / max</p>
+          <svg viewBox="0 0 ${dW} ${dH}" preserveAspectRatio="xMidYMid meet" style="display:block;max-width:100%;">
+            <!-- Whisker line (min to max) -->
+            <line x1="${sx(dist.min)}" y1="${whiskerY}" x2="${sx(dist.max)}" y2="${whiskerY}" stroke="#666" stroke-width="1"/>
+            <!-- Min cap -->
+            <line x1="${sx(dist.min)}" y1="${boxY + 5}" x2="${sx(dist.min)}" y2="${boxY + boxH - 5}" stroke="#666" stroke-width="1.5"/>
+            <!-- Max cap -->
+            <line x1="${sx(dist.max)}" y1="${boxY + 5}" x2="${sx(dist.max)}" y2="${boxY + boxH - 5}" stroke="#666" stroke-width="1.5"/>
+            <!-- IQR box (Q1 to Q3) -->
+            <rect x="${sx(dist.q1)}" y="${boxY}" width="${sx(dist.q3) - sx(dist.q1)}" height="${boxH}" rx="3" fill="var(--orange)" opacity="0.35" stroke="var(--orange)" stroke-width="1"/>
+            <!-- Median line -->
+            <line x1="${sx(dist.median)}" y1="${boxY}" x2="${sx(dist.median)}" y2="${boxY + boxH}" stroke="#fff" stroke-width="2"/>
+            <!-- Labels -->
+            <text x="${sx(dist.min)}" y="${boxY - 4}" text-anchor="middle" fill="#888" font-size="9" font-family="Inter">${dist.min.toFixed(3)}</text>
+            <text x="${sx(dist.q1)}" y="${boxY + boxH + 12}" text-anchor="middle" fill="#aaa" font-size="9" font-family="Inter">Q1 ${dist.q1.toFixed(3)}</text>
+            <text x="${sx(dist.median)}" y="${boxY - 4}" text-anchor="middle" fill="#fff" font-size="10" font-family="Oswald" font-weight="600">${dist.median.toFixed(3)}</text>
+            <text x="${sx(dist.q3)}" y="${boxY + boxH + 12}" text-anchor="middle" fill="#aaa" font-size="9" font-family="Inter">Q3 ${dist.q3.toFixed(3)}</text>
+            <text x="${sx(dist.max)}" y="${boxY - 4}" text-anchor="middle" fill="#888" font-size="9" font-family="Inter">${dist.max.toFixed(3)}</text>
+            <!-- Dot plot -->
+            ${dist.scores.map(s => `<circle cx="${sx(s)}" cy="${whiskerY}" r="2.5" fill="var(--orange)" opacity="0.4"/>`).join('')}
+          </svg>
+        </div>`;
+    }
+
     // All-time leaderboard — top individual scores across all meets
     const individualScores = [];
     meets.forEach(m => {
@@ -3176,6 +3476,51 @@
 
     const deepDive = buildDeepDive();
 
+    // ── Lineup Position Analysis ──
+    const posResult = StatsLib.getLineupPositionStats(meets, eventKey);
+    const posStats = posResult.positions || [];
+    const hasPositionData = posStats.some(p => p.count > 0);
+    let positionChart = '';
+    if (hasPositionData) {
+      const posW = 400, posH = 160;
+      const posPad = { top: 20, right: 20, bottom: 30, left: 50 };
+      const posAvgs = posStats.map(p => p.avg || 0);
+      const posMin = Math.min(...posAvgs.filter(v => v > 0)) - 0.05;
+      const posMax = Math.max(...posAvgs) + 0.05;
+      const posRange = posMax - posMin || 1;
+      const barW = 40, barGap = 15;
+
+      const posBars = posStats.map((p, i) => {
+        if (!p.avg) return '';
+        const x = posPad.left + i * (barW + barGap);
+        const barH = Math.max(4, ((p.avg - posMin) / posRange) * (posH - posPad.top - posPad.bottom));
+        const y = posH - posPad.bottom - barH;
+        const isAnchor = p.position === 6;
+        const isLeadoff = p.position === 1;
+        const fill = isAnchor ? '#D73F09' : isLeadoff ? '#f39c12' : 'var(--orange)';
+        const opacity = (isAnchor || isLeadoff) ? '1' : '0.6';
+        const label = isAnchor ? 'Anchor' : isLeadoff ? 'Leadoff' : '';
+        return `
+          <g>
+            <rect x="${x}" y="${y}" width="${barW}" height="${barH}" rx="3" fill="${fill}" opacity="${opacity}">
+              <title>Position ${p.position}: avg ${p.avg ? p.avg.toFixed(3) : '—'} (${p.count} scores)</title>
+            </rect>
+            <text x="${x + barW/2}" y="${y - 4}" text-anchor="middle" fill="${(isAnchor||isLeadoff) ? '#fff' : '#aaa'}" font-size="10" font-family="Oswald">${p.avg ? p.avg.toFixed(3) : '—'}</text>
+            <text x="${x + barW/2}" y="${posH - 10}" text-anchor="middle" fill="#999" font-size="10" font-family="Inter">#${p.position}</text>
+            ${label ? `<text x="${x + barW/2}" y="${posH}" text-anchor="middle" fill="${fill}" font-size="8" font-family="Inter" font-weight="600">${label}</text>` : ''}
+          </g>`;
+      }).join('');
+
+      positionChart = `
+        <div class="section-card">
+          <h2 class="section-title">Lineup Position Analysis</h2>
+          <p style="color:var(--text-muted);font-size:0.8rem;margin-bottom:0.75rem;">Average score by lineup position. <span style="color:#f39c12">Leadoff</span> sets the tone, <span style="color:#D73F09">Anchor</span> closes it out.</p>
+          <svg viewBox="0 0 ${posPad.left + 6*(barW+barGap)} ${posH + 5}" preserveAspectRatio="xMidYMid meet" style="display:block;max-width:100%;">
+            ${posBars}
+          </svg>
+        </div>`;
+    }
+
     document.getElementById('eventDetailContent').innerHTML = `
       <div class="event-detail-header">
         <div class="event-banner-content">
@@ -3185,6 +3530,8 @@
       </div>
       ${chart}
       ${statsPanel}
+      ${distributionChart}
+      ${positionChart}
       ${gymnastSection}
       ${leaderboard}
       ${breakdown}
@@ -3248,23 +3595,44 @@
       return;
     }
 
+    // AA-specific: add trend arrow when >=3 entries
+    const isAA = event === 'aa';
+
     list.innerHTML = gymnasts.map((g, i) => {
       const photo = photos[g.name];
       const avatar = photo
         ? `<img src="${photo}" class="lb-avatar" alt="${g.name}">`
         : `<div class="lb-avatar lb-avatar-initials">${g.name.split(' ').map(n => n[0]).join('')}</div>`;
+
+      // Trend indicator for AA
+      let trendHtml = '';
+      if (isAA && g.count >= 3) {
+        const half = Math.floor(g.count / 2);
+        const scores = byGymnast[g.name].map(e => e.score);
+        const firstAvg = mean(scores.slice(0, half || 1));
+        const secondAvg = mean(scores.slice(half || 1));
+        const diff = secondAvg - firstAvg;
+        const arrow = diff > 0.05 ? '▲' : diff < -0.05 ? '▼' : '►';
+        const color = diff > 0.05 ? '#2ecc71' : diff < -0.05 ? '#e74c3c' : '#aaa';
+        trendHtml = `<div class="lb-stat"><span class="lb-stat-label">TREND</span><span class="lb-stat-val" style="color:${color}">${arrow}</span></div>`;
+      } else if (isAA && g.count < 3) {
+        trendHtml = `<div class="lb-stat"><span class="lb-stat-label">n</span><span class="lb-stat-val" style="color:var(--text-muted)">${g.count}</span></div>`;
+      }
+
+      const dp = isAA ? 3 : 3;
       return `
       <div class="leaderboard-item">
         <div class="lb-rank ${i < 3 ? 'top-3' : ''}">${i + 1}</div>
         ${avatar}
         <div class="lb-info">
           <div class="lb-name"><span class="clickable-name" data-gymnast="${g.name}">${g.name}</span></div>
-          <div class="lb-context">Best: <span class="clickable-meet" data-meet-id="${g.best.meetId}">${formatDate(g.best.meetDate)} vs ${g.best.opponent}</span></div>
+          <div class="lb-context">Best: <span class="clickable-meet" data-meet-id="${g.best.meetId}">${formatDate(g.best.meetDate)} vs ${g.best.opponent}</span>${isAA ? ` <span style="color:var(--text-muted);font-size:0.75rem">(${g.count} AA entries)</span>` : ''}</div>
         </div>
         <div class="lb-stats">
-          <div class="lb-stat"><span class="lb-stat-label">HIGH</span><span class="lb-stat-val">${g.best.score.toFixed(3)}</span></div>
-          <div class="lb-stat"><span class="lb-stat-label">AVG</span><span class="lb-stat-val">${g.avg.toFixed(3)}</span></div>
-          <div class="lb-stat"><span class="lb-stat-label">LAST</span><span class="lb-stat-val">${g.recent.score.toFixed(3)}</span></div>
+          <div class="lb-stat"><span class="lb-stat-label">HIGH</span><span class="lb-stat-val">${g.best.score.toFixed(dp)}</span></div>
+          <div class="lb-stat"><span class="lb-stat-label">AVG</span><span class="lb-stat-val">${g.avg.toFixed(dp)}</span></div>
+          <div class="lb-stat"><span class="lb-stat-label">LAST</span><span class="lb-stat-val">${g.recent.score.toFixed(dp)}</span></div>
+          ${trendHtml}
         </div>
       </div>`;
     }).join('');
@@ -3273,7 +3641,7 @@
   // ===== Insights =====
   function renderInsights() {
     // --- helpers ---
-    const linReg = Stats.linReg;
+    const linReg = StatsLib.linReg;
     function fmtDiff(n) { if (typeof n !== 'number' || isNaN(n)) return '—'; return (n>=0?'+':'')+n.toFixed(3); }
 
     const EVS = ['vault','bars','beam','floor'];
@@ -4058,7 +4426,7 @@
 // ===== Season Wild Stats =====
   function renderSeasonWildStats() {
     // ── Shared stats helpers (delegated to Stats module) ────────────────────
-    const sd = Stats.stddev;
+    const sd = StatsLib.stddev;
     function corrStrength(r) {
       const a = Math.abs(r);
       if(a < 0.2) return 'negligible';
@@ -4410,10 +4778,20 @@
       renderGymnasts(e.target.value);
     });
 
+    // Compare toggle
+    document.getElementById('compareToggleBtn').addEventListener('click', toggleCompareMode);
+    document.getElementById('compareCancelBtn').addEventListener('click', toggleCompareMode);
+    document.getElementById('compareGoBtn').addEventListener('click', renderComparison);
+
     // Gymnast card click
     document.getElementById('gymnastCards').addEventListener('click', e => {
       const card = e.target.closest('.gymnast-card');
-      if (card) showGymnastProfile(card.dataset.gymnast);
+      if (!card) return;
+      if (compareMode) {
+        handleCompareSelect(card.dataset.gymnast);
+        return;
+      }
+      showGymnastProfile(card.dataset.gymnast);
     });
 
     // Event tabs

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,317 +1,483 @@
-/* ===== OSU Gymnastics 2026 — Stats Module ===== */
+/* ===== OSU Gymnastics 2026 - Stats Module ===== */
+/* Shared statistical computation library.
+   Loaded before app.js; available as window.StatsLib in browser,
+   or via module.exports in Node. */
 
-window.Stats = (function () {
+(function (root) {
   'use strict';
 
-  // ── Core Math ─────────────────────────────────────────────────────────────
+  var EVENTS = ['vault', 'bars', 'beam', 'floor'];
+
+  // ───── Core Math ─────
+
   function mean(arr) {
-    return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : null;
+    if (!arr || !arr.length) return null;
+    return arr.reduce(function (s, v) { return s + v; }, 0) / arr.length;
   }
 
+  /** Population standard deviation (N denominator). */
   function stddev(arr) {
-    if (arr.length < 2) return 0;
-    const m = mean(arr);
-    return Math.sqrt(arr.reduce((s, v) => s + Math.pow(v - m, 2), 0) / (arr.length - 1));
+    if (!arr || arr.length < 2) return 0;
+    var m = mean(arr);
+    var sumSq = arr.reduce(function (s, v) { return s + Math.pow(v - m, 2); }, 0);
+    return Math.sqrt(sumSq / arr.length);
   }
 
+  /** Pearson correlation coefficient. Returns null if n < 3 or zero variance. */
   function pearson(xs, ys) {
-    const n = xs.length;
+    var n = xs.length;
     if (n < 3) return null;
-    const mx = mean(xs), my = mean(ys);
-    const num = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0);
-    const den = Math.sqrt(
-      xs.reduce((s, x) => s + Math.pow(x - mx, 2), 0) *
-      ys.reduce((s, y) => s + Math.pow(y - my, 2), 0)
+    var mx = mean(xs), my = mean(ys);
+    var num = xs.reduce(function (s, x, i) { return s + (x - mx) * (ys[i] - my); }, 0);
+    var den = Math.sqrt(
+      xs.reduce(function (s, x) { return s + Math.pow(x - mx, 2); }, 0) *
+      ys.reduce(function (s, y) { return s + Math.pow(y - my, 2); }, 0)
     );
     return den === 0 ? null : num / den;
   }
 
+  /** Simple linear regression. Returns { slope, intercept, r2 }. */
   function linReg(pts) {
-    const n = pts.length;
-    if (n < 2) return { slope: 0 };
-    const sx = pts.reduce((s, p) => s + p.x, 0);
-    const sy = pts.reduce((s, p) => s + p.y, 0);
-    const sxy = pts.reduce((s, p) => s + p.x * p.y, 0);
-    const sx2 = pts.reduce((s, p) => s + p.x * p.x, 0);
-    return { slope: (n * sxy - sx * sy) / (n * sx2 - sx * sx) || 0 };
+    var n = pts.length;
+    if (n < 2) return { slope: 0, intercept: 0, r2: 0 };
+    var sx = 0, sy = 0, sxy = 0, sx2 = 0;
+    for (var i = 0; i < n; i++) {
+      sx += pts[i].x;
+      sy += pts[i].y;
+      sxy += pts[i].x * pts[i].y;
+      sx2 += pts[i].x * pts[i].x;
+    }
+    var denom = n * sx2 - sx * sx;
+    if (denom === 0) return { slope: 0, intercept: sy / n, r2: 0 };
+    var slope = (n * sxy - sx * sy) / denom;
+    var intercept = (sy - slope * sx) / n;
+    var my = sy / n;
+    var ssRes = 0, ssTot = 0;
+    for (var j = 0; j < n; j++) {
+      var predicted = slope * pts[j].x + intercept;
+      ssRes += Math.pow(pts[j].y - predicted, 2);
+      ssTot += Math.pow(pts[j].y - my, 2);
+    }
+    var r2 = ssTot === 0 ? 0 : 1 - ssRes / ssTot;
+    return { slope: slope, intercept: intercept, r2: r2 };
   }
 
-  // ── Helpers ───────────────────────────────────────────────────────────────
-  const EVENTS = ['vault', 'bars', 'beam', 'floor'];
+  function fmt(n, dp) {
+    if (dp === undefined) dp = 3;
+    return n != null && !isNaN(n) ? n.toFixed(dp) : '\u2014';
+  }
+
+  // ───── Data Helpers ─────
 
   function sortedByDate(meets) {
-    return meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+    return meets.slice().sort(function (a, b) { return a.date.localeCompare(b.date); });
+  }
+
+  /** Deduplicate meets to unique competition days (by date), sorted chronologically. */
+  function dedupByDate(meets) {
+    var seen = {};
+    var out = [];
+    var sorted = sortedByDate(meets);
+    for (var i = 0; i < sorted.length; i++) {
+      if (!seen[sorted[i].date]) {
+        seen[sorted[i].date] = true;
+        out.push(sorted[i]);
+      }
+    }
+    return out;
   }
 
   // ── getAthleteEntries ─────────────────────────────────────────────────────
   // Returns chronological array of {score, date, meetId, opponent, isHome, result}
   // for a given athlete + event, deduped by date (quad meet days).
   function getAthleteEntries(meets, name, event) {
-    const out = [];
-    const seenDates = new Set();
-    sortedByDate(meets).forEach(meet => {
-      if (seenDates.has(meet.date)) return;
-      const a = meet.athletes.find(x => x.name === name);
-      if (a && a.scores[event] !== undefined) {
-        seenDates.add(meet.date);
-        out.push({
-          score: a.scores[event],
-          date: meet.date,
-          meetId: meet.id,
-          opponent: meet.opponent,
-          isHome: meet.isHome,
-          result: meet.result
-        });
+    var out = [];
+    var seenDates = {};
+    var sorted = sortedByDate(meets);
+    for (var i = 0; i < sorted.length; i++) {
+      var m = sorted[i];
+      if (seenDates[m.date]) continue;
+      if (!m.athletes) continue;
+      for (var j = 0; j < m.athletes.length; j++) {
+        var a = m.athletes[j];
+        if (a.name === name && a.scores[event] !== undefined) {
+          seenDates[m.date] = true;
+          out.push({
+            score: a.scores[event],
+            date: m.date,
+            meetId: m.id,
+            opponent: m.opponent || '?',
+            isHome: m.isHome,
+            result: m.result
+          });
+          break;
+        }
       }
-    });
+    }
     return out;
   }
 
   // ── getAthleteStats ───────────────────────────────────────────────────────
-  // Returns per-event + overall stats for an athlete.
+  // Returns { perEvent: { vault: {avg,best,worst,sd,trend,scores[],count}, ... }, aa: {scores[],avg,best,count} }
   function getAthleteStats(meets, name) {
-    const stats = {};
-    EVENTS.forEach(ev => {
-      const entries = getAthleteEntries(meets, name, ev);
-      if (!entries.length) return;
-      const scores = entries.map(e => e.score);
-      stats[ev] = {
-        count: scores.length,
+    var perEvent = {};
+    for (var ei = 0; ei < EVENTS.length; ei++) {
+      var ev = EVENTS[ei];
+      var entries = getAthleteEntries(meets, name, ev);
+      if (!entries.length) continue;
+      var scores = entries.map(function (e) { return e.score; });
+      var pts = entries.map(function (e, i) { return { x: i, y: e.score }; });
+      var reg = linReg(pts);
+      perEvent[ev] = {
         avg: mean(scores),
-        best: Math.max(...scores),
-        worst: Math.min(...scores),
-        stddev: stddev(scores),
+        best: Math.max.apply(null, scores),
+        worst: Math.min.apply(null, scores),
+        sd: stddev(scores),
+        trend: reg.slope,
         scores: scores,
+        count: scores.length,
         entries: entries
       };
-    });
-    // AA
-    const aaEntries = getAthleteEntries(meets, name, 'aa');
-    if (aaEntries.length) {
-      const aaScores = aaEntries.map(e => e.score);
-      stats.aa = {
-        count: aaScores.length,
-        avg: mean(aaScores),
-        best: Math.max(...aaScores),
-        worst: Math.min(...aaScores),
-        stddev: stddev(aaScores),
-        scores: aaScores,
-        entries: aaEntries
-      };
     }
-    // Overall
-    const allScores = EVENTS.flatMap(ev => (stats[ev] || { scores: [] }).scores);
-    stats.overall = {
-      count: allScores.length,
-      avg: mean(allScores),
-      stddev: stddev(allScores)
+
+    // AA scores
+    var aaEntries = getAthleteEntries(meets, name, 'aa');
+    var aaScores = aaEntries.map(function (e) { return e.score; });
+    var aa = {
+      scores: aaScores,
+      avg: aaScores.length ? mean(aaScores) : null,
+      best: aaScores.length ? Math.max.apply(null, aaScores) : null,
+      count: aaScores.length,
+      entries: aaEntries
     };
-    return stats;
+
+    return { perEvent: perEvent, aa: aa };
   }
 
   // ── getEventStats ─────────────────────────────────────────────────────────
-  // Team event stats across the season.
+  // Team event stats across the season, deduped by date.
+  // Returns { avg, best, worst, sd, trend, byMeet: [{date, score, opponent, meetId}] }
   function getEventStats(meets, event) {
-    const scores = [];
-    const seenDates = new Set();
-    sortedByDate(meets).forEach(m => {
-      if (seenDates.has(m.date)) return;
+    var deduped = dedupByDate(meets);
+    var byMeet = [];
+    for (var i = 0; i < deduped.length; i++) {
+      var m = deduped[i];
       if (m.events && m.events[event] && m.events[event].osu > 0) {
-        seenDates.add(m.date);
-        scores.push({
-          score: m.events[event].osu,
-          oppScore: m.events[event].opponent,
-          date: m.date,
-          meetId: m.id,
-          opponent: m.opponent
-        });
+        byMeet.push({ date: m.date, score: m.events[event].osu, opponent: m.opponent, meetId: m.id });
       }
-    });
-    const vals = scores.map(s => s.score);
+    }
+    var scores = byMeet.map(function (e) { return e.score; });
+    if (!scores.length) return { avg: null, best: null, worst: null, sd: 0, trend: 0, byMeet: [] };
+    var pts = byMeet.map(function (e, i) { return { x: i, y: e.score }; });
+    var reg = linReg(pts);
     return {
-      count: vals.length,
-      avg: mean(vals),
-      best: vals.length ? Math.max(...vals) : null,
-      worst: vals.length ? Math.min(...vals) : null,
-      stddev: stddev(vals),
-      entries: scores
+      avg: mean(scores),
+      best: Math.max.apply(null, scores),
+      worst: Math.min.apply(null, scores),
+      sd: stddev(scores),
+      trend: reg.slope,
+      byMeet: byMeet
     };
   }
 
   // ── getTeamSeasonStats ────────────────────────────────────────────────────
+  // Returns { record:{w,l}, totalAvg, byEvent:{vault:{avg,best},...}, seasonHigh, recentN:[] }
   function getTeamSeasonStats(meets) {
-    const compDays = [];
-    const seenDates = new Set();
-    sortedByDate(meets).forEach(m => {
-      if (seenDates.has(m.date)) return;
-      if (!m.osuScore || m.osuScore <= 0) return;
-      seenDates.add(m.date);
-      compDays.push(m);
+    var deduped = dedupByDate(meets);
+    var scored = deduped.filter(function (m) { return m.osuScore && m.osuScore > 0; });
+    var totals = scored.map(function (m) { return m.osuScore; });
+
+    var w = 0, l = 0;
+    meets.forEach(function (m) {
+      if (m.result === 'W') w++;
+      else if (m.result === 'L') l++;
     });
-    const totals = compDays.map(m => m.osuScore);
-    const wins = meets.filter(m => m.result === 'W').length;
-    const losses = meets.filter(m => m.result === 'L').length;
+
+    var byEvent = {};
+    EVENTS.forEach(function (ev) {
+      var evScores = scored
+        .filter(function (m) { return m.events && m.events[ev] && m.events[ev].osu > 0; })
+        .map(function (m) { return m.events[ev].osu; });
+      if (evScores.length) {
+        byEvent[ev] = { avg: mean(evScores), best: Math.max.apply(null, evScores) };
+      }
+    });
+
     return {
-      meetCount: compDays.length,
-      wins: wins,
-      losses: losses,
-      avg: mean(totals),
-      best: totals.length ? Math.max(...totals) : null,
-      worst: totals.length ? Math.min(...totals) : null,
-      stddev: stddev(totals),
-      compDays: compDays
+      record: { w: w, l: l },
+      totalAvg: mean(totals),
+      byEvent: byEvent,
+      seasonHigh: totals.length ? Math.max.apply(null, totals) : null,
+      recentN: totals.slice(-3),
+      compDays: scored
     };
   }
 
   // ── getSeasonRankings ─────────────────────────────────────────────────────
-  // Team season rankings from allTeams data across all meets, deduped by date.
+  // Aggregates allTeams[] across all meets (deduped by date) into a ranked table.
+  // Returns [{ team, appearances, avgTotal, bestTotal, vault, bars, beam, floor }]
   function getSeasonRankings(meets) {
-    const teamTotals = {};
-    const seenDates = new Set();
-    sortedByDate(meets).forEach(m => {
-      if (!m.allTeams || seenDates.has(m.date)) return;
-      seenDates.add(m.date);
-      m.allTeams.forEach(t => {
-        if (!teamTotals[t.team]) {
-          teamTotals[t.team] = { scores: [], vault: [], bars: [], beam: [], floor: [] };
-        }
-        if (t.total > 0) teamTotals[t.team].scores.push(t.total);
-        if (t.vault > 0) teamTotals[t.team].vault.push(t.vault);
-        if (t.bars > 0) teamTotals[t.team].bars.push(t.bars);
-        if (t.beam > 0) teamTotals[t.team].beam.push(t.beam);
-        if (t.floor > 0) teamTotals[t.team].floor.push(t.floor);
-      });
+    var teamMap = {};
+    var deduped = dedupByDate(meets);
+    for (var i = 0; i < deduped.length; i++) {
+      var m = deduped[i];
+      if (!m.allTeams) continue;
+      for (var j = 0; j < m.allTeams.length; j++) {
+        var t = m.allTeams[j];
+        if (!t.team || t.total == null) continue;
+        var key = t.team.trim();
+        if (!teamMap[key]) teamMap[key] = { totals: [], vaults: [], barss: [], beams: [], floors: [] };
+        teamMap[key].totals.push(t.total);
+        if (t.vault != null) teamMap[key].vaults.push(t.vault);
+        if (t.bars != null) teamMap[key].barss.push(t.bars);
+        if (t.beam != null) teamMap[key].beams.push(t.beam);
+        if (t.floor != null) teamMap[key].floors.push(t.floor);
+      }
+    }
+
+    var rankings = Object.keys(teamMap).map(function (key) {
+      var d = teamMap[key];
+      return {
+        team: key,
+        appearances: d.totals.length,
+        avgTotal: mean(d.totals),
+        bestTotal: Math.max.apply(null, d.totals),
+        vault: mean(d.vaults),
+        bars: mean(d.barss),
+        beam: mean(d.beams),
+        floor: mean(d.floors)
+      };
     });
-    return Object.entries(teamTotals)
-      .map(([team, data]) => ({
-        team: team,
-        avg: mean(data.scores),
-        best: data.scores.length ? Math.max(...data.scores) : null,
-        meets: data.scores.length,
-        vaultAvg: mean(data.vault),
-        barsAvg: mean(data.bars),
-        beamAvg: mean(data.beam),
-        floorAvg: mean(data.floor)
-      }))
-      .filter(t => t.avg != null)
-      .sort((a, b) => b.avg - a.avg);
+    rankings.sort(function (a, b) { return b.avgTotal - a.avgTotal; });
+    return rankings;
   }
 
   // ── getLineupPositionStats ────────────────────────────────────────────────
-  // Average score by lineup position 1-6 for a given event.
+  // Returns { positions: [{position, avg, count, best, scores[]}], anchor: {name,avg,count}, leadoff: {name,avg,count} }
   function getLineupPositionStats(meets, event) {
-    const positions = {};
-    for (let i = 1; i <= 6; i++) positions[i] = [];
+    var posMap = {};
+    var anchorMap = {};
+    var leadoffMap = {};
+    var deduped = dedupByDate(meets);
 
-    meets.forEach(m => {
-      if (!m.lineups || !m.lineups[event]) return;
-      m.lineups[event].forEach(entry => {
-        if (entry.position >= 1 && entry.position <= 6 && entry.score > 0) {
-          positions[entry.position].push(entry.score);
+    for (var i = 0; i < deduped.length; i++) {
+      var m = deduped[i];
+      if (!m.lineups || !m.lineups[event] || m.lineups[event].length < 5) continue;
+      var lineup = m.lineups[event];
+      var maxPos = lineup.length;
+
+      for (var j = 0; j < lineup.length; j++) {
+        var entry = lineup[j];
+        var pos = entry.position || (j + 1);
+        if (!posMap[pos]) posMap[pos] = [];
+        posMap[pos].push(entry.score);
+
+        if (pos === maxPos) {
+          if (!anchorMap[entry.name]) anchorMap[entry.name] = [];
+          anchorMap[entry.name].push(entry.score);
+        }
+        if (pos === 1) {
+          if (!leadoffMap[entry.name]) leadoffMap[entry.name] = [];
+          leadoffMap[entry.name].push(entry.score);
+        }
+      }
+    }
+
+    var positions = Object.keys(posMap).map(function (pos) {
+      var scores = posMap[pos];
+      return {
+        position: parseInt(pos, 10),
+        avg: mean(scores),
+        count: scores.length,
+        best: Math.max.apply(null, scores),
+        scores: scores
+      };
+    }).sort(function (a, b) { return a.position - b.position; });
+
+    function topPerformer(map) {
+      var best = null;
+      Object.keys(map).forEach(function (name) {
+        var scores = map[name];
+        if (!best || scores.length > best.count) {
+          best = { name: name, avg: mean(scores), count: scores.length };
         }
       });
-    });
+      return best;
+    }
 
-    return Object.entries(positions).map(([pos, scores]) => ({
-      position: parseInt(pos),
-      avg: mean(scores),
-      count: scores.length,
-      best: scores.length ? Math.max(...scores) : null,
-      stddev: stddev(scores),
-      scores: scores
-    }));
+    return {
+      positions: positions,
+      anchor: topPerformer(anchorMap),
+      leadoff: topPerformer(leadoffMap)
+    };
   }
 
   // ── getRollingAverage ─────────────────────────────────────────────────────
-  // Returns array of {date, avg} for n-meet rolling average of team total.
+  // Returns [{date, avg, score}] for n-meet rolling average of team total.
   function getRollingAverage(meets, n) {
-    const compDays = [];
-    const seenDates = new Set();
-    sortedByDate(meets).forEach(m => {
-      if (seenDates.has(m.date) || !m.osuScore || m.osuScore <= 0) return;
-      seenDates.add(m.date);
-      compDays.push({ date: m.date, score: m.osuScore });
-    });
-
-    const result = [];
-    for (let i = n - 1; i < compDays.length; i++) {
-      const window = compDays.slice(i - n + 1, i + 1);
-      result.push({
-        date: compDays[i].date,
-        avg: mean(window.map(w => w.score)),
-        index: i
-      });
+    if (!n) n = 3;
+    var deduped = dedupByDate(meets);
+    var scored = deduped.filter(function (m) { return m.osuScore && m.osuScore > 0; });
+    var result = [];
+    for (var i = 0; i < scored.length; i++) {
+      if (i < n - 1) {
+        result.push({ date: scored[i].date, avg: null, score: scored[i].osuScore });
+        continue;
+      }
+      var window = [];
+      for (var j = i - n + 1; j <= i; j++) window.push(scored[j].osuScore);
+      result.push({ date: scored[i].date, avg: mean(window), score: scored[i].osuScore });
     }
     return result;
   }
 
   // ── getAALeaderboard ──────────────────────────────────────────────────────
-  // All-Around leaderboard from scores.aa field.
+  // Returns [{ name, best, avg, count, trend, entries }] sorted by best AA.
   function getAALeaderboard(meets) {
-    const byGymnast = {};
-    sortedByDate(meets).forEach(meet => {
-      meet.athletes.forEach(a => {
-        if (a.scores && a.scores.aa !== undefined) {
-          if (!byGymnast[a.name]) byGymnast[a.name] = [];
-          byGymnast[a.name].push({
-            score: a.scores.aa,
-            meetDate: meet.date,
-            opponent: meet.opponent,
-            meetId: meet.id
-          });
+    var byName = {};
+    var sorted = sortedByDate(meets);
+    for (var i = 0; i < sorted.length; i++) {
+      var m = sorted[i];
+      if (!m.athletes) continue;
+      for (var j = 0; j < m.athletes.length; j++) {
+        var a = m.athletes[j];
+        if (a.scores && a.scores.aa != null && a.team === 'Oregon State') {
+          if (!byName[a.name]) byName[a.name] = [];
+          var exists = false;
+          for (var k = 0; k < byName[a.name].length; k++) {
+            if (byName[a.name][k].date === m.date) { exists = true; break; }
+          }
+          if (!exists) {
+            byName[a.name].push({ score: a.scores.aa, date: m.date, meetId: m.id, opponent: m.opponent });
+          }
+        }
+      }
+    }
+
+    var result = [];
+    Object.keys(byName).forEach(function (name) {
+      var entries = byName[name];
+      var scores = entries.map(function (e) { return e.score; });
+      var pts = entries.map(function (e, i) { return { x: i, y: e.score }; });
+      var reg = linReg(pts);
+      var bestEntry = entries.reduce(function (a, b) { return a.score > b.score ? a : b; });
+      result.push({
+        name: name,
+        best: bestEntry.score,
+        bestEntry: bestEntry,
+        avg: mean(scores),
+        count: scores.length,
+        trend: reg.slope,
+        entries: entries
+      });
+    });
+    result.sort(function (a, b) { return b.best - a.best; });
+    return result;
+  }
+
+  // ── getAthleteComparisonData ──────────────────────────────────────────────
+  // Returns { a: athleteStats, b: athleteStats, sharedEvents: [], sharedDates: [] }
+  function getAthleteComparisonData(meets, nameA, nameB) {
+    var statsA = getAthleteStats(meets, nameA);
+    var statsB = getAthleteStats(meets, nameB);
+
+    var sharedEvents = [];
+    EVENTS.forEach(function (ev) {
+      if (statsA.perEvent[ev] && statsB.perEvent[ev]) sharedEvents.push(ev);
+    });
+
+    var datesA = {}, datesB = {};
+    sortedByDate(meets).forEach(function (m) {
+      if (!m.athletes) return;
+      m.athletes.forEach(function (a) {
+        if (a.name === nameA) datesA[m.date] = true;
+        if (a.name === nameB) datesB[m.date] = true;
+      });
+    });
+    var sharedDates = Object.keys(datesA).filter(function (d) { return datesB[d]; }).sort();
+
+    return { a: statsA, b: statsB, sharedEvents: sharedEvents, sharedDates: sharedDates };
+  }
+
+  // ── getNQSBreakdown ───────────────────────────────────────────────────────
+  // Returns { scores: [{name,score,dropped}], nqs, dropName, dropScore } or null.
+  function getNQSBreakdown(meet, event) {
+    if (!meet.lineups || !meet.lineups[event] || meet.lineups[event].length < 5) return null;
+    var lineup = meet.lineups[event].slice().sort(function (a, b) { return a.position - b.position; });
+    var scores = lineup.map(function (e) {
+      return { name: e.name, score: e.score, position: e.position, dropped: false };
+    });
+
+    if (scores.length >= 6) {
+      var minIdx = 0;
+      for (var i = 1; i < scores.length; i++) {
+        if (scores[i].score < scores[minIdx].score) minIdx = i;
+      }
+      scores[minIdx].dropped = true;
+    }
+
+    var counting = scores.filter(function (s) { return !s.dropped; });
+    var nqs = counting.reduce(function (sum, s) { return sum + s.score; }, 0);
+    var dropped = scores.find(function (s) { return s.dropped; });
+
+    return {
+      scores: scores,
+      nqs: nqs,
+      dropName: dropped ? dropped.name : null,
+      dropScore: dropped ? dropped.score : null
+    };
+  }
+
+  // ── getScoreDistribution ──────────────────────────────────────────────────
+  // Returns { min, q1, median, q3, max, scores[] } for OSU individual scores on an event.
+  function getScoreDistribution(meets, event) {
+    var allScores = [];
+    var seenKeys = {};
+    meets.forEach(function (m) {
+      if (!m.athletes) return;
+      m.athletes.forEach(function (a) {
+        if (a.team !== 'Oregon State') return;
+        if (a.scores[event] !== undefined && a.scores[event] > 0) {
+          var key = a.name + '|' + m.date;
+          if (!seenKeys[key]) {
+            seenKeys[key] = true;
+            allScores.push(a.scores[event]);
+          }
         }
       });
     });
 
-    return Object.entries(byGymnast).map(([name, entries]) => {
-      const scores = entries.map(e => e.score);
-      const best = entries.reduce((a, b) => a.score > b.score ? a : b);
-      const recent = entries[entries.length - 1];
-      // Trend: compare first half to second half
-      const half = Math.floor(scores.length / 2);
-      let trend = null;
-      if (scores.length >= 3) {
-        const firstAvg = mean(scores.slice(0, half || 1));
-        const secondAvg = mean(scores.slice(half || 1));
-        trend = secondAvg - firstAvg;
-      }
-      return {
-        name: name,
-        best: best,
-        avg: mean(scores),
-        recent: recent,
-        count: scores.length,
-        scores: scores,
-        entries: entries,
-        trend: trend
-      };
-    }).sort((a, b) => b.best.score - a.best.score);
-  }
+    allScores.sort(function (a, b) { return a - b; });
+    var n = allScores.length;
+    if (n === 0) return { min: null, q1: null, median: null, q3: null, max: null, scores: [] };
 
-  // ── getAthleteComparisonData ──────────────────────────────────────────────
-  // Side-by-side stats for two athletes on a given event (or all events).
-  function getAthleteComparisonData(meets, name1, name2, event) {
-    if (event) {
-      return {
-        athlete1: { name: name1, entries: getAthleteEntries(meets, name1, event) },
-        athlete2: { name: name2, entries: getAthleteEntries(meets, name2, event) }
-      };
+    function quantile(arr, q) {
+      var pos = (arr.length - 1) * q;
+      var base = Math.floor(pos);
+      var rest = pos - base;
+      if (arr[base + 1] !== undefined) return arr[base] + rest * (arr[base + 1] - arr[base]);
+      return arr[base];
     }
-    // All events comparison
-    const stats1 = getAthleteStats(meets, name1);
-    const stats2 = getAthleteStats(meets, name2);
+
     return {
-      athlete1: { name: name1, stats: stats1 },
-      athlete2: { name: name2, stats: stats2 }
+      min: allScores[0],
+      q1: quantile(allScores, 0.25),
+      median: quantile(allScores, 0.5),
+      q3: quantile(allScores, 0.75),
+      max: allScores[n - 1],
+      scores: allScores
     };
   }
 
-  // ── Public API ────────────────────────────────────────────────────────────
-  return {
+  // ───── Export ─────
+  var StatsLib = {
     mean: mean,
     stddev: stddev,
     pearson: pearson,
     linReg: linReg,
+    fmt: fmt,
+    EVENTS: EVENTS,
+    dedupByDate: dedupByDate,
     getAthleteEntries: getAthleteEntries,
     getAthleteStats: getAthleteStats,
     getEventStats: getEventStats,
@@ -320,6 +486,15 @@ window.Stats = (function () {
     getLineupPositionStats: getLineupPositionStats,
     getRollingAverage: getRollingAverage,
     getAALeaderboard: getAALeaderboard,
-    getAthleteComparisonData: getAthleteComparisonData
+    getAthleteComparisonData: getAthleteComparisonData,
+    getNQSBreakdown: getNQSBreakdown,
+    getScoreDistribution: getScoreDistribution
   };
-})();
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = StatsLib;
+  }
+  if (typeof root !== 'undefined') {
+    root.StatsLib = StatsLib;
+  }
+})(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : this);

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,0 +1,325 @@
+/* ===== OSU Gymnastics 2026 — Stats Module ===== */
+
+window.Stats = (function () {
+  'use strict';
+
+  // ── Core Math ─────────────────────────────────────────────────────────────
+  function mean(arr) {
+    return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : null;
+  }
+
+  function stddev(arr) {
+    if (arr.length < 2) return 0;
+    const m = mean(arr);
+    return Math.sqrt(arr.reduce((s, v) => s + Math.pow(v - m, 2), 0) / (arr.length - 1));
+  }
+
+  function pearson(xs, ys) {
+    const n = xs.length;
+    if (n < 3) return null;
+    const mx = mean(xs), my = mean(ys);
+    const num = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0);
+    const den = Math.sqrt(
+      xs.reduce((s, x) => s + Math.pow(x - mx, 2), 0) *
+      ys.reduce((s, y) => s + Math.pow(y - my, 2), 0)
+    );
+    return den === 0 ? null : num / den;
+  }
+
+  function linReg(pts) {
+    const n = pts.length;
+    if (n < 2) return { slope: 0 };
+    const sx = pts.reduce((s, p) => s + p.x, 0);
+    const sy = pts.reduce((s, p) => s + p.y, 0);
+    const sxy = pts.reduce((s, p) => s + p.x * p.y, 0);
+    const sx2 = pts.reduce((s, p) => s + p.x * p.x, 0);
+    return { slope: (n * sxy - sx * sy) / (n * sx2 - sx * sx) || 0 };
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  const EVENTS = ['vault', 'bars', 'beam', 'floor'];
+
+  function sortedByDate(meets) {
+    return meets.slice().sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  // ── getAthleteEntries ─────────────────────────────────────────────────────
+  // Returns chronological array of {score, date, meetId, opponent, isHome, result}
+  // for a given athlete + event, deduped by date (quad meet days).
+  function getAthleteEntries(meets, name, event) {
+    const out = [];
+    const seenDates = new Set();
+    sortedByDate(meets).forEach(meet => {
+      if (seenDates.has(meet.date)) return;
+      const a = meet.athletes.find(x => x.name === name);
+      if (a && a.scores[event] !== undefined) {
+        seenDates.add(meet.date);
+        out.push({
+          score: a.scores[event],
+          date: meet.date,
+          meetId: meet.id,
+          opponent: meet.opponent,
+          isHome: meet.isHome,
+          result: meet.result
+        });
+      }
+    });
+    return out;
+  }
+
+  // ── getAthleteStats ───────────────────────────────────────────────────────
+  // Returns per-event + overall stats for an athlete.
+  function getAthleteStats(meets, name) {
+    const stats = {};
+    EVENTS.forEach(ev => {
+      const entries = getAthleteEntries(meets, name, ev);
+      if (!entries.length) return;
+      const scores = entries.map(e => e.score);
+      stats[ev] = {
+        count: scores.length,
+        avg: mean(scores),
+        best: Math.max(...scores),
+        worst: Math.min(...scores),
+        stddev: stddev(scores),
+        scores: scores,
+        entries: entries
+      };
+    });
+    // AA
+    const aaEntries = getAthleteEntries(meets, name, 'aa');
+    if (aaEntries.length) {
+      const aaScores = aaEntries.map(e => e.score);
+      stats.aa = {
+        count: aaScores.length,
+        avg: mean(aaScores),
+        best: Math.max(...aaScores),
+        worst: Math.min(...aaScores),
+        stddev: stddev(aaScores),
+        scores: aaScores,
+        entries: aaEntries
+      };
+    }
+    // Overall
+    const allScores = EVENTS.flatMap(ev => (stats[ev] || { scores: [] }).scores);
+    stats.overall = {
+      count: allScores.length,
+      avg: mean(allScores),
+      stddev: stddev(allScores)
+    };
+    return stats;
+  }
+
+  // ── getEventStats ─────────────────────────────────────────────────────────
+  // Team event stats across the season.
+  function getEventStats(meets, event) {
+    const scores = [];
+    const seenDates = new Set();
+    sortedByDate(meets).forEach(m => {
+      if (seenDates.has(m.date)) return;
+      if (m.events && m.events[event] && m.events[event].osu > 0) {
+        seenDates.add(m.date);
+        scores.push({
+          score: m.events[event].osu,
+          oppScore: m.events[event].opponent,
+          date: m.date,
+          meetId: m.id,
+          opponent: m.opponent
+        });
+      }
+    });
+    const vals = scores.map(s => s.score);
+    return {
+      count: vals.length,
+      avg: mean(vals),
+      best: vals.length ? Math.max(...vals) : null,
+      worst: vals.length ? Math.min(...vals) : null,
+      stddev: stddev(vals),
+      entries: scores
+    };
+  }
+
+  // ── getTeamSeasonStats ────────────────────────────────────────────────────
+  function getTeamSeasonStats(meets) {
+    const compDays = [];
+    const seenDates = new Set();
+    sortedByDate(meets).forEach(m => {
+      if (seenDates.has(m.date)) return;
+      if (!m.osuScore || m.osuScore <= 0) return;
+      seenDates.add(m.date);
+      compDays.push(m);
+    });
+    const totals = compDays.map(m => m.osuScore);
+    const wins = meets.filter(m => m.result === 'W').length;
+    const losses = meets.filter(m => m.result === 'L').length;
+    return {
+      meetCount: compDays.length,
+      wins: wins,
+      losses: losses,
+      avg: mean(totals),
+      best: totals.length ? Math.max(...totals) : null,
+      worst: totals.length ? Math.min(...totals) : null,
+      stddev: stddev(totals),
+      compDays: compDays
+    };
+  }
+
+  // ── getSeasonRankings ─────────────────────────────────────────────────────
+  // Team season rankings from allTeams data across all meets, deduped by date.
+  function getSeasonRankings(meets) {
+    const teamTotals = {};
+    const seenDates = new Set();
+    sortedByDate(meets).forEach(m => {
+      if (!m.allTeams || seenDates.has(m.date)) return;
+      seenDates.add(m.date);
+      m.allTeams.forEach(t => {
+        if (!teamTotals[t.team]) {
+          teamTotals[t.team] = { scores: [], vault: [], bars: [], beam: [], floor: [] };
+        }
+        if (t.total > 0) teamTotals[t.team].scores.push(t.total);
+        if (t.vault > 0) teamTotals[t.team].vault.push(t.vault);
+        if (t.bars > 0) teamTotals[t.team].bars.push(t.bars);
+        if (t.beam > 0) teamTotals[t.team].beam.push(t.beam);
+        if (t.floor > 0) teamTotals[t.team].floor.push(t.floor);
+      });
+    });
+    return Object.entries(teamTotals)
+      .map(([team, data]) => ({
+        team: team,
+        avg: mean(data.scores),
+        best: data.scores.length ? Math.max(...data.scores) : null,
+        meets: data.scores.length,
+        vaultAvg: mean(data.vault),
+        barsAvg: mean(data.bars),
+        beamAvg: mean(data.beam),
+        floorAvg: mean(data.floor)
+      }))
+      .filter(t => t.avg != null)
+      .sort((a, b) => b.avg - a.avg);
+  }
+
+  // ── getLineupPositionStats ────────────────────────────────────────────────
+  // Average score by lineup position 1-6 for a given event.
+  function getLineupPositionStats(meets, event) {
+    const positions = {};
+    for (let i = 1; i <= 6; i++) positions[i] = [];
+
+    meets.forEach(m => {
+      if (!m.lineups || !m.lineups[event]) return;
+      m.lineups[event].forEach(entry => {
+        if (entry.position >= 1 && entry.position <= 6 && entry.score > 0) {
+          positions[entry.position].push(entry.score);
+        }
+      });
+    });
+
+    return Object.entries(positions).map(([pos, scores]) => ({
+      position: parseInt(pos),
+      avg: mean(scores),
+      count: scores.length,
+      best: scores.length ? Math.max(...scores) : null,
+      stddev: stddev(scores),
+      scores: scores
+    }));
+  }
+
+  // ── getRollingAverage ─────────────────────────────────────────────────────
+  // Returns array of {date, avg} for n-meet rolling average of team total.
+  function getRollingAverage(meets, n) {
+    const compDays = [];
+    const seenDates = new Set();
+    sortedByDate(meets).forEach(m => {
+      if (seenDates.has(m.date) || !m.osuScore || m.osuScore <= 0) return;
+      seenDates.add(m.date);
+      compDays.push({ date: m.date, score: m.osuScore });
+    });
+
+    const result = [];
+    for (let i = n - 1; i < compDays.length; i++) {
+      const window = compDays.slice(i - n + 1, i + 1);
+      result.push({
+        date: compDays[i].date,
+        avg: mean(window.map(w => w.score)),
+        index: i
+      });
+    }
+    return result;
+  }
+
+  // ── getAALeaderboard ──────────────────────────────────────────────────────
+  // All-Around leaderboard from scores.aa field.
+  function getAALeaderboard(meets) {
+    const byGymnast = {};
+    sortedByDate(meets).forEach(meet => {
+      meet.athletes.forEach(a => {
+        if (a.scores && a.scores.aa !== undefined) {
+          if (!byGymnast[a.name]) byGymnast[a.name] = [];
+          byGymnast[a.name].push({
+            score: a.scores.aa,
+            meetDate: meet.date,
+            opponent: meet.opponent,
+            meetId: meet.id
+          });
+        }
+      });
+    });
+
+    return Object.entries(byGymnast).map(([name, entries]) => {
+      const scores = entries.map(e => e.score);
+      const best = entries.reduce((a, b) => a.score > b.score ? a : b);
+      const recent = entries[entries.length - 1];
+      // Trend: compare first half to second half
+      const half = Math.floor(scores.length / 2);
+      let trend = null;
+      if (scores.length >= 3) {
+        const firstAvg = mean(scores.slice(0, half || 1));
+        const secondAvg = mean(scores.slice(half || 1));
+        trend = secondAvg - firstAvg;
+      }
+      return {
+        name: name,
+        best: best,
+        avg: mean(scores),
+        recent: recent,
+        count: scores.length,
+        scores: scores,
+        entries: entries,
+        trend: trend
+      };
+    }).sort((a, b) => b.best.score - a.best.score);
+  }
+
+  // ── getAthleteComparisonData ──────────────────────────────────────────────
+  // Side-by-side stats for two athletes on a given event (or all events).
+  function getAthleteComparisonData(meets, name1, name2, event) {
+    if (event) {
+      return {
+        athlete1: { name: name1, entries: getAthleteEntries(meets, name1, event) },
+        athlete2: { name: name2, entries: getAthleteEntries(meets, name2, event) }
+      };
+    }
+    // All events comparison
+    const stats1 = getAthleteStats(meets, name1);
+    const stats2 = getAthleteStats(meets, name2);
+    return {
+      athlete1: { name: name1, stats: stats1 },
+      athlete2: { name: name2, stats: stats2 }
+    };
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+  return {
+    mean: mean,
+    stddev: stddev,
+    pearson: pearson,
+    linReg: linReg,
+    getAthleteEntries: getAthleteEntries,
+    getAthleteStats: getAthleteStats,
+    getEventStats: getEventStats,
+    getTeamSeasonStats: getTeamSeasonStats,
+    getSeasonRankings: getSeasonRankings,
+    getLineupPositionStats: getLineupPositionStats,
+    getRollingAverage: getRollingAverage,
+    getAALeaderboard: getAALeaderboard,
+    getAthleteComparisonData: getAthleteComparisonData
+  };
+})();

--- a/scripts/test_stats.js
+++ b/scripts/test_stats.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for StatsLib (public/js/stats.js).
+ * Run: node scripts/test_stats.js
+ */
+
+const StatsLib = require('../public/js/stats.js');
+const fs = require('fs');
+const path = require('path');
+
+let passes = 0;
+let failures = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passes++;
+  } else {
+    failures++;
+    console.error(`  FAIL: ${label}`);
+  }
+}
+
+function assertClose(actual, expected, tolerance, label) {
+  const ok = actual != null && Math.abs(actual - expected) < tolerance;
+  if (ok) {
+    passes++;
+  } else {
+    failures++;
+    console.error(`  FAIL: ${label} — expected ~${expected}, got ${actual}`);
+  }
+}
+
+// ── Core math tests ──
+
+console.log('Testing core math...');
+assert(StatsLib.mean([1, 2, 3]) === 2, 'mean([1,2,3]) = 2');
+assert(StatsLib.mean([]) === null, 'mean([]) = null');
+assert(StatsLib.mean([5]) === 5, 'mean([5]) = 5');
+
+assertClose(StatsLib.stddev([2, 4, 4, 4, 5, 5, 7, 9]), 2.0, 0.1, 'stddev basic');
+assert(StatsLib.stddev([]) === 0, 'stddev([]) = 0');
+assert(StatsLib.stddev([5]) === 0, 'stddev([5]) = 0');
+
+assert(StatsLib.pearson([1, 2], [3, 4]) === null, 'pearson n<3 = null');
+const r = StatsLib.pearson([1, 2, 3, 4, 5], [2, 4, 6, 8, 10]);
+assertClose(r, 1.0, 0.001, 'pearson perfect positive');
+const rNeg = StatsLib.pearson([1, 2, 3, 4, 5], [10, 8, 6, 4, 2]);
+assertClose(rNeg, -1.0, 0.001, 'pearson perfect negative');
+
+const reg = StatsLib.linReg([{x:0,y:1},{x:1,y:3},{x:2,y:5}]);
+assertClose(reg.slope, 2.0, 0.001, 'linReg slope = 2');
+
+const regSingle = StatsLib.linReg([{x:0,y:5}]);
+assert(regSingle.slope === 0, 'linReg single point slope = 0');
+
+// ── Data function tests with real data ──
+
+console.log('Testing data functions...');
+const meetsPath = path.join(__dirname, '..', 'data', 'meets.json');
+const meets = JSON.parse(fs.readFileSync(meetsPath, 'utf-8'));
+
+// getAthleteEntries
+const esposito = StatsLib.getAthleteEntries(meets, 'Sophia Esposito', 'vault');
+assert(esposito.length > 0, 'Esposito has vault entries');
+assert(esposito.every(e => typeof e.score === 'number' && e.score > 0), 'All entries have valid scores');
+// Should be deduped by date
+const dates = esposito.map(e => e.date);
+assert(new Set(dates).size === dates.length, 'Entries deduped by date');
+
+// getAthleteStats
+const stats = StatsLib.getAthleteStats(meets, 'Sophia Esposito');
+assert(stats.perEvent.vault != null, 'Esposito has vault stats');
+assert(stats.perEvent.vault.avg > 9.0, 'Esposito vault avg > 9.0');
+assert(stats.perEvent.vault.best >= stats.perEvent.vault.avg, 'Best >= avg');
+
+// AA entries
+const aaEntries = StatsLib.getAthleteEntries(meets, 'Sophia Esposito', 'aa');
+// Esposito has some AA scores per the issue description
+assert(aaEntries.length >= 0, 'AA entries exist or are empty');
+
+// getEventStats
+const vaultStats = StatsLib.getEventStats(meets, 'vault');
+assert(vaultStats.avg > 40, 'Team vault avg > 40');
+assert(vaultStats.best >= vaultStats.avg, 'Team vault best >= avg');
+
+// getTeamSeasonStats
+const teamStats = StatsLib.getTeamSeasonStats(meets);
+assert(teamStats.totalAvg > 190, 'Team total avg > 190');
+assert(teamStats.record.w + teamStats.record.l > 0, 'Has W/L record');
+
+// getSeasonRankings
+const rankings = StatsLib.getSeasonRankings(meets);
+assert(rankings.length > 0, 'Has season rankings');
+assert(rankings[0].avgTotal > 0, 'Top team has positive avg');
+const osuRank = rankings.find(t => t.team.toLowerCase().includes('oregon'));
+assert(osuRank != null, 'Oregon State in rankings');
+
+// getLineupPositionStats
+const posStats = StatsLib.getLineupPositionStats(meets, 'vault');
+assert(posStats.positions.length > 0, 'Has position stats');
+assert(posStats.positions[0].position === 1, 'First position is 1');
+
+// getRollingAverage
+const rolling = StatsLib.getRollingAverage(meets, 3);
+assert(rolling.length > 0, 'Has rolling averages');
+assert(rolling[0].avg === null, 'First entry has null avg (window not full)');
+const validRolling = rolling.filter(r => r.avg != null);
+assert(validRolling.length > 0, 'Has valid rolling avg entries');
+assert(validRolling[0].avg > 190, 'Rolling avg > 190');
+
+// getAALeaderboard
+const aaBoard = StatsLib.getAALeaderboard(meets);
+// May have entries or may not depending on data
+assert(Array.isArray(aaBoard), 'AA leaderboard is array');
+
+// getAthleteComparisonData
+const comp = StatsLib.getAthleteComparisonData(meets, 'Sophia Esposito', 'Camryn Richardson');
+assert(comp.a != null && comp.b != null, 'Comparison has both athletes');
+assert(Array.isArray(comp.sharedEvents), 'Comparison has shared events');
+
+// getNQSBreakdown
+const meetWithLineup = meets.find(m => m.lineups && m.lineups.vault && m.lineups.vault.length >= 6);
+if (meetWithLineup) {
+  const nqs = StatsLib.getNQSBreakdown(meetWithLineup, 'vault');
+  assert(nqs != null, 'NQS breakdown exists for meet with lineup');
+  assert(nqs.scores.length >= 6, 'NQS has 6+ scores');
+  const dropped = nqs.scores.filter(s => s.dropped);
+  assert(dropped.length === 1, 'Exactly one dropped score');
+  assert(nqs.nqs > 0, 'NQS total > 0');
+}
+
+// getScoreDistribution
+const dist = StatsLib.getScoreDistribution(meets, 'vault');
+assert(dist.scores.length > 0, 'Score distribution has scores');
+assert(dist.min <= dist.q1, 'min <= q1');
+assert(dist.q1 <= dist.median, 'q1 <= median');
+assert(dist.median <= dist.q3, 'median <= q3');
+assert(dist.q3 <= dist.max, 'q3 <= max');
+
+// ── Summary ──
+
+console.log(`\nResults: ${passes} passed, ${failures} failed`);
+if (failures > 0) {
+  console.log('FAIL: Some StatsLib tests failed.');
+  process.exit(1);
+} else {
+  console.log('PASS: All StatsLib tests passed.');
+  process.exit(0);
+}

--- a/scripts/validate_data.js
+++ b/scripts/validate_data.js
@@ -131,6 +131,53 @@ meets.forEach((m, i) => {
       }
     });
   }
+
+  // Lineup validation
+  if (m.lineups && typeof m.lineups === 'object') {
+    EVENTS.forEach(ev => {
+      const lineup = m.lineups[ev];
+      if (!lineup || !Array.isArray(lineup)) return;
+      lineup.forEach(entry => {
+        if (!entry.name) {
+          error(m.id, `Lineup ${ev}: entry missing name`);
+        }
+        if (typeof entry.score !== 'number' || entry.score < 0 || entry.score > 10.5) {
+          warn(m.id, `Lineup ${ev}: ${entry.name || '?'} score ${entry.score} outside range [0-10.5]`);
+        }
+        if (typeof entry.position !== 'number' || entry.position < 1 || entry.position > 6) {
+          warn(m.id, `Lineup ${ev}: ${entry.name || '?'} invalid position ${entry.position}`);
+        }
+      });
+      // NQS: if 6 entries, sum of top 5 should match event total (within tolerance)
+      if (lineup.length === 6 && m.events && m.events[ev] && m.events[ev].osu) {
+        const sorted = lineup.map(e => e.score).sort((a, b) => a - b);
+        const top5sum = sorted.slice(1).reduce((s, v) => s + v, 0);
+        const eventTotal = m.events[ev].osu;
+        if (Math.abs(top5sum - eventTotal) > 0.01) {
+          warn(m.id, `Lineup ${ev}: NQS top-5 sum (${top5sum.toFixed(3)}) != event total (${eventTotal.toFixed(3)})`);
+        }
+      }
+    });
+  }
+
+  // allTeams validation
+  if (m.allTeams && Array.isArray(m.allTeams)) {
+    m.allTeams.forEach(t => {
+      if (!t.team) {
+        error(m.id, 'allTeams entry missing team name');
+      }
+      if (t.total != null && (t.total < 140 || t.total > 200)) {
+        warn(m.id, `allTeams ${t.team}: total ${t.total} outside range [140-200]`);
+      }
+    });
+    // Check Oregon State is in allTeams for quad meets
+    if (m.quadMeet) {
+      const hasOSU = m.allTeams.some(t => t.team && t.team.toLowerCase().includes('oregon'));
+      if (!hasOSU) {
+        warn(m.id, 'Quad meet allTeams[] missing Oregon State');
+      }
+    }
+  }
 });
 
 console.log(`\nResults: ${errors} error(s), ${warnings} warning(s)`);


### PR DESCRIPTION
## Summary

Implements all 8 phases from the stats analytics research (issue #31/#33).

### Phases Implemented

**Phase 1 — Shared `stats.js` module**
- `mean()`, `stddev()`, `pearson()`, `linReg()` extracted from app.js
- `getAthleteStats()`, `getEventStats()`, `getTeamSeasonStats()`
- `getSeasonRankings()`, `getLineupPositionStats()`
- `getRollingAverage()`, `getAALeaderboard()`

**Phase 2 — All-Around Leaderboard**
- AA tab in leaderboard view (best, avg, count, trend arrow)
- AA column in gymnast meet history table

**Phase 3 — NQS Display**
- Meet detail: lineup scores with dropped score marked
- Season overview and event cards show projected NQS chip

**Phase 4 — Lineup Position Analysis**
- Position 1–6 bar chart on event detail view
- Anchor (pos 6) and Leadoff (pos 1) spotlights

**Phase 5 — Team Season Rankings**
- Rankings table in season overview from quad meet data
- OSU row highlighted in orange

**Phase 6 — Score Distribution + Rolling Averages**
- Distribution chart on event detail view
- 3-meet rolling average overlay on season trend chart
- Momentum indicator (↑/→/↓) on season overview hero

**Phase 7 — Athlete Comparison View**
- Compare button in gymnasts view
- Side-by-side stat cards + sparkline overlay

**Phase 8 — Tests + CSS**
- 43 StatsLib unit tests (`scripts/test_stats.js`) — all passing
- Extended `validate_data.js` with lineup/allTeams checks
- CSS for all new UI components

### Validation
- `node scripts/validate_data.js` — 0 errors, 0 warnings
- `node scripts/test_stats.js` — 43/43 tests pass

Addresses issue #33