### PR TITLE
Fix: Chatbot API returning 500 error - API key configuration issue

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,79 @@
+# Fixes Applied for Issue #56
+
+## Problem
+The chatbot API endpoint `/api/chat` was returning 500 errors with "Failed to process chat message". The API key was not being loaded from the .env file.
+
+## Root Causes
+1. **Missing dotenv package**: The `dotenv` package was not installed in the project dependencies
+2. **Missing dotenv initialization**: `require('dotenv').config()` was not called in server.js
+3. **No .env file**: Only `.env.example` existed; users need to create `.env` with their API key
+4. **Insufficient logging**: Startup logs didn't clearly show whether API key was loaded
+
+## Changes Made
+
+### 1. Added dotenv package (package.json)
+- Added `"dotenv": "^16.4.5"` to dependencies
+- This package loads environment variables from .env files
+
+### 2. Initialize dotenv in server.js
+- Added `require('dotenv').config()` at the top of server.js (before any other requires)
+- This loads environment variables from `.env` file into `process.env`
+
+### 3. Enhanced startup logging
+- Added detailed configuration status on startup
+- Shows whether ANTHROPIC_API_KEY is loaded (with preview: `sk-ant-api1234...wxyz`)
+- Provides step-by-step instructions if API key is missing
+- Shows REFRESH_SECRET status as well
+
+### 4. Improved error logging in /api/chat endpoint
+- Added `[Chat API]` prefix to all logs for easy filtering
+- Logs request details (number of messages)
+- Enhanced error details (status, type, name)
+- More helpful error messages that mention .env file
+
+## Setup Instructions for Users
+
+After pulling these changes, users need to:
+
+1. **Install dependencies** (includes new dotenv package):
+   ```bash
+   npm install
+   ```
+
+2. **Create .env file** from the example:
+   ```bash
+   cp .env.example .env
+   ```
+
+3. **Add API key** to .env:
+   - Get API key from https://console.anthropic.com
+   - Edit `.env` and replace `sk-ant-your-key-here` with actual key
+
+4. **Restart server**:
+   ```bash
+   npm start
+   ```
+
+5. **Verify startup logs** show:
+   ```
+   ✅ ANTHROPIC_API_KEY is loaded (sk-ant-api1234...wxyz)
+   💬 Chatbot features enabled
+   ```
+
+6. **Test chatbot**: Open http://localhost:8888 and click the chat bubble
+
+## Testing Checklist
+
+- [x] Code changes made (dotenv added, logging enhanced)
+- [ ] Dependencies installed (`npm install`)
+- [ ] .env file created with valid API key
+- [ ] Server starts without errors
+- [ ] Startup logs show API key is loaded
+- [ ] Chatbot UI accepts messages
+- [ ] Claude responds to messages
+- [ ] No 500 errors in server logs
+
+## Files Changed
+- `server.js`: Added dotenv initialization and enhanced logging
+- `package.json`: Added dotenv dependency
+- `FIXES.md` (this file): Documentation of changes

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.24.0",
+    "dotenv": "^16.4.5",
     "express": "^5.2.1",
     "ws": "^8.20.0"
   }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,6 @@
+// Load environment variables from .env file
+require('dotenv').config();
+
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
@@ -277,15 +280,20 @@ app.post('/api/chat', async (req, res) => {
     const { messages } = req.body;
 
     if (!messages || !Array.isArray(messages)) {
+      console.error('[Chat API] Invalid request - messages array required');
       return res.status(400).json({ error: 'Messages array required' });
     }
 
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      console.error('ANTHROPIC_API_KEY not set');
-      return res.status(500).json({ error: 'AI service not configured' });
+      console.error('[Chat API] ANTHROPIC_API_KEY environment variable is not set');
+      console.error('[Chat API] Please create .env file with your API key (see .env.example)');
+      return res.status(500).json({ 
+        error: 'AI service not configured. Please add ANTHROPIC_API_KEY to .env file.' 
+      });
     }
 
+    console.log('[Chat API] Processing request with', messages.length, 'messages');
     const client = new Anthropic({ apiKey });
 
     // Format messages for Claude API
@@ -338,19 +346,32 @@ app.post('/api/chat', async (req, res) => {
 
     const assistantMessage = response.content[0]?.text || '';
 
+    console.log('[Chat API] Successfully generated response');
     res.json({
       success: true,
       message: assistantMessage,
     });
   } catch (error) {
-    console.error('Chat API error:', error.message);
+    console.error('[Chat API] Error:', error.message);
+    console.error('[Chat API] Error details:', {
+      status: error.status,
+      type: error.type,
+      name: error.name
+    });
+    
     if (error.status === 401) {
-      return res.status(500).json({ error: 'Invalid API credentials' });
+      console.error('[Chat API] Authentication failed - check if your ANTHROPIC_API_KEY is valid');
+      return res.status(500).json({ 
+        error: 'Invalid API credentials. Please check your ANTHROPIC_API_KEY in .env file.' 
+      });
     }
     if (error.status === 429) {
+      console.error('[Chat API] Rate limit exceeded');
       return res.status(429).json({ error: 'Rate limited. Please try again later.' });
     }
-    res.status(500).json({ error: 'Failed to process chat message' });
+    res.status(500).json({ 
+      error: 'Failed to process chat message: ' + error.message 
+    });
   }
 });
 
@@ -430,14 +451,28 @@ setInterval(() => {
 server.listen(PORT, () => {
   console.log(`🤸 OSU Gymnastics 2026 running on http://localhost:${PORT}`);
   console.log(`📡 WebSocket server available at ws://localhost:${PORT}/ws`);
+  console.log('');
   
   // Check for required and optional configuration
-  if (!ANTHROPIC_API_KEY) {
-    console.warn('⚠️  WARNING: ANTHROPIC_API_KEY env var is not set');
-    console.warn('   Chatbot AI features will not work');
-    console.warn('   See CHATBOT_SETUP.md for configuration instructions');
+  console.log('📋 Configuration Status:');
+  if (ANTHROPIC_API_KEY) {
+    const keyPreview = ANTHROPIC_API_KEY.substring(0, 12) + '...' + ANTHROPIC_API_KEY.substring(ANTHROPIC_API_KEY.length - 4);
+    console.log(`   ✅ ANTHROPIC_API_KEY is loaded (${keyPreview})`);
+    console.log('   💬 Chatbot features enabled');
+  } else {
+    console.warn('   ⚠️  ANTHROPIC_API_KEY is NOT set');
+    console.warn('   ❌ Chatbot AI features will not work');
+    console.warn('   📝 Action required:');
+    console.warn('      1. Copy .env.example to .env: cp .env.example .env');
+    console.warn('      2. Edit .env and add your Anthropic API key');
+    console.warn('      3. Get API key from: https://console.anthropic.com');
+    console.warn('      4. Restart the server: npm start');
   }
+  
   if (!REFRESH_SECRET) {
-    console.warn('⚠️  WARNING: REFRESH_SECRET env var is not set — POST /api/refresh is unprotected');
+    console.warn('   ⚠️  REFRESH_SECRET is not set — POST /api/refresh is unprotected');
+  } else {
+    console.log('   ✅ REFRESH_SECRET is set');
   }
+  console.log('');
 });


### PR DESCRIPTION
## Summary
Fixes #56 - Addresses chatbot API endpoint returning 500 errors due to missing dotenv configuration.

## Root Causes
1. **Missing dotenv package**: Not installed in dependencies
2. **Missing dotenv initialization**: `require('dotenv').config()` not called
3. **No .env file**: Users need to create from .env.example
4. **Insufficient logging**: Startup didn't show API key status

## Changes
- ✅ Added `dotenv` package to package.json dependencies
- ✅ Initialize dotenv at top of server.js to load .env file
- ✅ Enhanced startup logging with clear API key status and setup instructions
- ✅ Improved error logging in /api/chat endpoint with detailed debugging info
- ✅ Added FIXES.md documenting changes and setup instructions

## Setup Required After Merge
1. Run `npm install` to install dotenv package
2. Create .env file: `cp .env.example .env`
3. Add your Anthropic API key to .env file
4. Restart server: `npm start`
5. Verify startup logs show "✅ ANTHROPIC_API_KEY is loaded"

## Testing
- [x] Code changes implemented
- [x] Improved logging shows configuration status
- [x] Error messages provide actionable guidance
- [ ] Requires .env file with valid API key to fully test (user action)

See FIXES.md for complete documentation.

Addresses issue #56